### PR TITLE
Switch to Inter font + fix rejected posts on map/search

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@
   [data-theme="forest-dark"] {
     --font-display: 'Syne', sans-serif;
     --font-serif: 'Libre Baskerville', Georgia, serif;
-    --font-body: 'DM Sans', system-ui, sans-serif;
+    --font-body: 'Inter', system-ui, sans-serif;
 
     /* Deep Forest palette */
     --bg: #1a2a20;

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -11,6 +11,7 @@ export default async function MapPage() {
     .from('posts')
     .select('id, type, title, details, category, contact_name, created_at, status, location_label, location_fuzzed_lat, location_fuzzed_lng')
     .eq('status', 'active')
+    .neq('moderation_status', 'rejected')
     .not('location_fuzzed_lat', 'is', null)
     .order('created_at', { ascending: false });
 

--- a/src/app/search/search-client.tsx
+++ b/src/app/search/search-client.tsx
@@ -20,6 +20,7 @@ export function SearchClient() {
     const term = `%${q.trim()}%`;
     const { data } = await supabase.from('posts').select('*, responses(*)')
       .eq('status', 'active')
+      .neq('moderation_status', 'rejected')
       .or(`title.ilike.${term},details.ilike.${term},contact_name.ilike.${term}`)
       .order('created_at', { ascending: false }).limit(50);
     setResults(data || []); setLoading(false);


### PR DESCRIPTION
Two changes:

**Inter font:** Switched body font from DM Sans to Inter as requested. The CSS var `--font-body` now uses Inter (already loaded from Google Fonts in the theme PR).

**Map/search bug fix:** Rejected posts were still showing on the map and in search results. The main feed already filtered them out with a moderation_status check, but the map and search queries were missing it. Added `.neq('moderation_status', 'rejected')` to both.