### PR TITLE
Fix: Post Something button, location hints, geocoding

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { PostFeed } from '@/components/post-feed';
 import { Header } from '@/components/header';
+import { PostSomethingButton } from '@/components/post-something-button';
 import { APP_NAME, APP_TAGLINE, APP_DESCRIPTION } from '@/lib/constants';
 import { getModeratorByEmail } from '@/lib/admin';
 
@@ -46,10 +47,7 @@ export default async function Home() {
           {APP_DESCRIPTION}
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3 mt-2">
-          <a href="/auth" className="px-8 py-3 text-sm font-bold uppercase tracking-wider transition-colors"
-            style={{ background: 'var(--card)', color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>
-            Post something
-          </a>
+          <PostSomethingButton />
           <a href="/map" className="px-8 py-3 text-sm font-bold uppercase tracking-wider transition-colors"
             style={{ border: '1.5px solid rgba(232,224,204,0.2)', color: 'var(--heading)', fontFamily: 'var(--font-display)' }}>
             View map

--- a/src/components/create-post-form.tsx
+++ b/src/components/create-post-form.tsx
@@ -168,7 +168,7 @@ export function CreatePostForm({ onClose }: CreatePostFormProps) {
                       Whereabouts? <span className="normal-case tracking-normal font-normal" style={{ color: 'var(--ink-muted)' }}>(optional — places a pin on the map)</span>
                     </label>
                     <p className="text-xs mb-2" style={{ color: 'var(--ink-muted)', fontSize: '0.68rem' }}>
-                      Nearest cross-street or landmark. We never show your exact location — only an approximate area.
+                      Use a nearby intersection for best results (neighbourhood names alone won&apos;t appear on the map). We never show your exact location — only an approximate area.
                     </p>
                     <input
                       type="text"
@@ -176,7 +176,7 @@ export function CreatePostForm({ onClose }: CreatePostFormProps) {
                       onChange={(e) => setCrossStreet(e.target.value)}
                       className="w-full px-4 py-3 text-sm focus:outline-none"
                       style={{ background: '#fff', border: '1px solid var(--border-card)', color: 'var(--ink)' }}
-                      placeholder="e.g. Dundas & Adelaide, or near Victoria Park"
+                      placeholder="e.g. Dundas & Adelaide, or Oxford & Wharncliffe"
                     />
                   </div>
 

--- a/src/components/post-something-button.tsx
+++ b/src/components/post-something-button.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { CreatePostForm } from './create-post-form';
+import { createClient } from '@/lib/supabase/client';
+
+export function PostSomethingButton() {
+  const [showCreate, setShowCreate] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsLoggedIn(!!user);
+    });
+  }, []);
+
+  return (
+    <>
+      <button
+        onClick={() => isLoggedIn ? setShowCreate(true) : window.location.href = '/auth?next=/'}
+        className="post-btn px-8 py-3 text-sm font-bold uppercase tracking-wider transition-colors"
+      >
+        Post something
+      </button>
+      {showCreate && <CreatePostForm onClose={() => setShowCreate(false)} />}
+    </>
+  );
+}

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -11,7 +11,22 @@
 export async function geocodeCrossStreet(crossStreet: string): Promise<{ lat: number; lng: number } | null> {
   const communityLocation = process.env.GEO_COMMUNITY_LOCATION || 'London, Ontario, Canada';
   const countryCode = process.env.GEO_COUNTRY_CODE || 'ca';
-  const query = `${crossStreet}, ${communityLocation}`;
+
+  // Try the original query first, then a neighbourhood fallback
+  const queries = [
+    `${crossStreet}, ${communityLocation}`,
+    `${crossStreet} neighbourhood, ${communityLocation}`,
+  ];
+
+  for (const query of queries) {
+    const result = await geocodeQuery(query, countryCode);
+    if (result) return result;
+  }
+
+  return null;
+}
+
+async function geocodeQuery(query: string, countryCode: string): Promise<{ lat: number; lng: number } | null> {
   const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=1&countrycodes=${countryCode}`;
 
   try {


### PR DESCRIPTION
Fixes from user feedback:

**1. Post Something button (homepage)**
Clicking 'Post something' when already logged in was redirecting to the account page instead of opening the create form. Now uses a client component that checks auth state and opens the post form directly (same behaviour as the header Post button).

**2. Location field hints**
Updated helper text and placeholder to explicitly encourage intersections over neighbourhood names. Neighbourhood names like 'Fairmount' don't geocode reliably with Nominatim, but intersections do.

**3. Geocoding fallback**
If the initial geocode query fails (e.g. just a neighbourhood name), now tries a second query appending 'neighbourhood' to help Nominatim find it.