### PR TITLE
feat: add intersection field to map display and post cards

### DIFF
--- a/src/app/map/map-client.tsx
+++ b/src/app/map/map-client.tsx
@@ -21,6 +21,7 @@ interface MapPost {
   created_at: string;
   status: string;
   location_label: string | null;
+  location_crossstreet: string | null;
   location_fuzzed_lat: number;
   location_fuzzed_lng: number;
 }
@@ -54,7 +55,7 @@ export function MapClient({ posts }: MapClientProps) {
         ))}
         {filtered.length === 0 && posts.length > 0 && (
           <span className="text-xs ml-2" style={{ color: 'var(--need)' }}>
-            No posts with locations yet — add a neighbourhood when creating a post
+            No posts with locations yet — add an intersection when creating a post
           </span>
         )}
       </div>
@@ -90,7 +91,7 @@ export function MapClient({ posts }: MapClientProps) {
               <div className="flex-1 min-w-0">
                 <div className="text-xs font-bold uppercase tracking-wider mb-1"
                   style={{ fontFamily: 'var(--font-display)', color: selected.type === 'need' ? 'var(--need)' : 'var(--offer)', fontSize: '0.6rem' }}>
-                  {selected.type} {selected.location_label ? `· ${selected.location_label}` : ''}
+                  {selected.type}{selected.location_label ? ` · ${selected.location_label}` : ''}{selected.location_crossstreet ? ` · ${selected.location_crossstreet}` : ''}
                 </div>
                 <h3 className="text-base leading-tight mb-1 truncate"
                   style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink)', fontWeight: 400 }}>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -9,7 +9,7 @@ export default async function MapPage() {
   const supabase = await createClient();
   const { data: posts } = await supabase
     .from('posts')
-    .select('id, type, title, details, category, contact_name, created_at, status, location_label, location_fuzzed_lat, location_fuzzed_lng')
+    .select('id, type, title, details, category, contact_name, created_at, status, location_label, location_crossstreet, location_fuzzed_lat, location_fuzzed_lng')
     .eq('status', 'active')
     .neq('moderation_status', 'rejected')
     .not('location_fuzzed_lat', 'is', null)

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -107,13 +107,13 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
             <span style={{ fontWeight: 600, color: 'var(--ink)' }}>{post.contact_name}</span>
             <span>&mdash;</span>
             <span>{timeAgo}</span>
-            {post.location_label && (
+            {(post.location_crossstreet || post.location_label) && (
               <>
                 <span>&mdash;</span>
-                <span className="truncate" style={{ maxWidth: '7.5rem' }}>{post.location_label}</span>
+                <span className="truncate" style={{ maxWidth: '7.5rem' }}>{post.location_crossstreet || post.location_label}</span>
               </>
             )}
-            {!post.location_label && categoryInfo && (
+            {!post.location_crossstreet && !post.location_label && categoryInfo && (
               <>
                 <span>&mdash;</span>
                 <span>{categoryInfo.label}</span>

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -22,6 +22,7 @@ export interface Post {
   status: PostStatus;
   user_id: string | null;
   location_label: string | null;
+  location_crossstreet: string | null;
   location_lat: number | null;
   location_lng: number | null;
   moderation_status: ModerationStatus | null;


### PR DESCRIPTION
## What

Adds the `location_crossstreet` field (intersection) to the map display and post cards so users can pinpoint their actual location beyond just a neighbourhood name.

## Why

Neighbourhoods are too large for walkability — users can't pinpoint their actual location from a neighbourhood name alone. The crossstreet field already existed in the DB and API, but the display layer wasn't using it.

## Changes

- **`src/types/database.ts`** — Add `location_crossstreet` to `Post` interface
- **`src/app/map/page.tsx`** — Include `location_crossstreet` in the map query
- **`src/app/map/map-client.tsx`** — Add to `MapPost` interface; show intersection label on selected post card
- **`src/components/post-card.tsx`** — Show intersection on post cards in the feed (falls back to `location_label`)
- Update map empty-state hint to reference 'intersection' instead of 'neighbourhood'

## How it works

- User enters an intersection in the post form (e.g. 'Queens Ave & Dundas St')
- API geocodes it and saves `location_crossstreet` to the DB (already implemented)
- Map query now fetches and displays the intersection text near the pin
- Post cards show the intersection alongside the neighbourhood

## Testing

- Form still submits correctly
- Map still filters by `moderation_status=rejected` and requires `location_fuzzed_lat`
- Existing posts without intersections fall back to `location_label`

## Constraints

- No production deploys — PR only
- Does not change the API schema (field already exists via migration `013_crossstreet_geocoding.sql`)
