### PR TITLE
refactor: replace inline styles with CSS classes (#11)

### DIFF
--- a/src/app/account/account-client.tsx
+++ b/src/app/account/account-client.tsx
@@ -10,9 +10,6 @@ import type { User } from '@supabase/supabase-js';
 import Link from 'next/link';
 import { useEffect } from 'react';
 
-const ds = { fontFamily: 'var(--font-display)' };
-const sr = { fontFamily: 'var(--font-serif)' };
-
 export function AccountClient({ user, posts }: { user: User; posts: PostWithResponses[] }) {
   const [updating, setUpdating] = useState<string | null>(null);
   const [emailNotifications, setEmailNotifications] = useState(true);
@@ -77,9 +74,9 @@ export function AccountClient({ user, posts }: { user: User; posts: PostWithResp
           { label: 'Fulfilled', value: fulfilledCount },
           { label: 'Responses', value: posts.reduce((a, p) => a + p.responses.length, 0) },
         ].map((s) => (
-          <div key={s.label} className="text-center py-4" style={{ background: 'var(--card)', border: '1px solid var(--border)' }}>
-            <p className="text-2xl font-bold" style={{ ...ds, color: 'var(--ink)' }}>{s.value}</p>
-            <p className="text-xs uppercase tracking-wide" style={{ ...ds, color: 'var(--ink-muted)', fontSize: '0.58rem' }}>{s.label}</p>
+          <div key={s.label} className="text-center py-4 card-theme">
+            <p className="text-2xl font-bold font-display color-ink">{s.value}</p>
+            <p className="text-xs uppercase tracking-wide font-display color-ink-muted" style={{ fontSize: '0.58rem' }}>{s.label}</p>
           </div>
         ))}
       </div>
@@ -87,40 +84,40 @@ export function AccountClient({ user, posts }: { user: User; posts: PostWithResp
       {/* Posts */}
       {posts.length === 0 ? (
         <div className="text-center py-12">
-          <p className="text-base italic mb-4" style={{ ...sr, color: 'var(--sub)' }}>You haven&apos;t posted anything yet.</p>
-          <Link href="/" className="text-xs font-bold uppercase tracking-wider px-6 py-3 transition-all"
-            style={{ ...ds, background: 'var(--card)', color: 'var(--ink)' }}>
+          <p className="text-base italic mb-4 font-serif color-sub">You haven&apos;t posted anything yet.</p>
+          <Link href="/" className="text-xs font-bold uppercase tracking-wider px-6 py-3 transition-all font-display"
+            style={{ background: 'var(--card)', color: 'var(--ink)' }}>
             Go to the board
           </Link>
         </div>
       ) : (
         <div className="space-y-3">
           {posts.map((post) => (
-            <div key={post.id} className="p-4" style={{ background: 'var(--card)', border: '1px solid var(--border)' }}>
+            <div key={post.id} className="p-4 card-theme">
               <div className="flex items-start justify-between gap-3 mb-2">
                 <div>
-                  <span className="text-xs font-bold uppercase tracking-wider mr-2"
-                    style={{ ...ds, color: post.type === 'need' ? 'var(--need)' : 'var(--offer)', fontSize: '0.6rem' }}>
+                  <span className="text-xs font-bold uppercase tracking-wider mr-2 font-display"
+                    style={{ color: post.type === 'need' ? 'var(--need)' : 'var(--offer)', fontSize: '0.6rem' }}>
                     {post.type}
                   </span>
-                  <span className="inline-block text-xs px-1.5 py-0.5 uppercase tracking-wider"
-                    style={{ ...ds, fontSize: '0.55rem', background: post.status === 'active' ? 'rgba(58,106,74,0.15)' : 'rgba(122,138,120,0.15)', color: post.status === 'active' ? 'var(--offer)' : 'var(--ink-muted)' }}>
+                  <span className="inline-block text-xs px-1.5 py-0.5 uppercase tracking-wider font-display"
+                    style={{ fontSize: '0.55rem', background: post.status === 'active' ? 'rgba(58,106,74,0.15)' : 'rgba(122,138,120,0.15)', color: post.status === 'active' ? 'var(--offer)' : 'var(--ink-muted)' }}>
                     {post.status}
                   </span>
                 </div>
-                <span className="text-xs flex-shrink-0" style={{ color: 'var(--ink-muted)' }}>
+                <span className="text-xs flex-shrink-0 color-ink-muted">
                   {formatDistanceToNow(new Date(post.created_at), { addSuffix: true })}
                 </span>
               </div>
 
               <Link href={`/post/${post.id}`}>
-                <h3 className="text-base mb-1 hover:underline" style={{ ...sr, color: 'var(--ink)', fontWeight: 400 }}>
+                <h3 className="text-base mb-1 hover:underline font-serif color-ink" style={{ fontWeight: 400 }}>
                   {post.title}
                 </h3>
               </Link>
 
               {post.responses.length > 0 && (
-                <div className="flex items-center gap-1 text-xs mb-3" style={{ color: 'var(--offer)' }}>
+                <div className="flex items-center gap-1 text-xs mb-3 color-offer">
                   <MessageCircle className="w-3 h-3" />
                   <span>{post.responses.length} {post.responses.length === 1 ? 'response' : 'responses'}</span>
                 </div>
@@ -129,18 +126,18 @@ export function AccountClient({ user, posts }: { user: User; posts: PostWithResp
               {post.status === 'active' && (
                 <div className="flex gap-2 pt-3" style={{ borderTop: '1px dashed var(--border-card)' }}>
                   <button onClick={() => updateStatus(post.id, 'fulfilled')} disabled={updating === post.id}
-                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
-                    style={{ ...ds, border: '1.5px solid var(--offer)', color: 'var(--offer)', background: 'transparent', fontSize: '0.6rem' }}>
+                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all font-display"
+                    style={{ border: '1.5px solid var(--offer)', color: 'var(--offer)', background: 'transparent', fontSize: '0.6rem' }}>
                     <CheckCircle className="w-3 h-3" /> Fulfilled
                   </button>
                   <button onClick={() => updateStatus(post.id, 'expired')} disabled={updating === post.id}
-                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
-                    style={{ ...ds, border: '1.5px solid var(--border-card)', color: 'var(--ink-muted)', background: 'transparent', fontSize: '0.6rem' }}>
+                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all font-display"
+                    style={{ border: '1.5px solid var(--border-card)', color: 'var(--ink-muted)', background: 'transparent', fontSize: '0.6rem' }}>
                     <XCircle className="w-3 h-3" /> Close
                   </button>
                   <button onClick={() => deletePost(post.id)} disabled={updating === post.id}
-                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
-                    style={{ ...ds, border: '1.5px solid rgba(208,112,64,0.3)', color: 'var(--need)', background: 'transparent', fontSize: '0.6rem' }}>
+                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all font-display"
+                    style={{ border: '1.5px solid rgba(208,112,64,0.3)', color: 'var(--need)', background: 'transparent', fontSize: '0.6rem' }}>
                     <Trash2 className="w-3 h-3" /> Delete
                   </button>
                 </div>
@@ -148,8 +145,8 @@ export function AccountClient({ user, posts }: { user: User; posts: PostWithResp
               {post.status !== 'active' && (
                 <div className="flex gap-2 pt-3" style={{ borderTop: '1px dashed var(--border-card)' }}>
                   <button onClick={() => deletePost(post.id)} disabled={updating === post.id}
-                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
-                    style={{ ...ds, border: '1.5px solid rgba(208,112,64,0.3)', color: 'var(--need)', background: 'transparent', fontSize: '0.6rem' }}>
+                    className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all font-display"
+                    style={{ border: '1.5px solid rgba(208,112,64,0.3)', color: 'var(--need)', background: 'transparent', fontSize: '0.6rem' }}>
                     <Trash2 className="w-3 h-3" /> Delete
                   </button>
                 </div>
@@ -160,34 +157,31 @@ export function AccountClient({ user, posts }: { user: User; posts: PostWithResp
       )}
 
       {/* Profile & Messages */}
-      <div className="mt-8 pt-6 space-y-3" style={{ borderTop: '1px solid var(--border)' }}>
-        <Link href="/account/profile" className="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold uppercase tracking-wider transition-all w-full"
-          style={{ ...ds, background: 'var(--card)', color: 'var(--ink)', border: '1px solid var(--border)' }}>
+      <div className="mt-8 pt-6 space-y-3 border-t-theme">
+        <Link href="/account/profile" className="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold uppercase tracking-wider transition-all w-full font-display card-theme color-ink">
           <UserCircle className="w-4 h-4" /> Edit Profile
         </Link>
-        <Link href="/messages" className="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold uppercase tracking-wider transition-all w-full"
-          style={{ ...ds, background: 'var(--card)', color: 'var(--ink)', border: '1px solid var(--border)' }}>
+        <Link href="/messages" className="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold uppercase tracking-wider transition-all w-full font-display card-theme color-ink">
           <MessageSquare className="w-4 h-4" /> My Messages
         </Link>
       </div>
 
       {/* Email notifications toggle */}
-      <div className="mt-4 pt-4" style={{ borderTop: '1px solid var(--border)' }}>
+      <div className="mt-4 pt-4 border-t-theme">
         <button
           onClick={toggleEmailNotifications}
           disabled={emailToggling}
-          className="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold uppercase tracking-wider transition-all w-full disabled:opacity-40"
-          style={{ ...ds, background: emailNotifications ? 'rgba(58,106,74,0.1)' : 'var(--card)', color: 'var(--ink)', border: `1px solid ${emailNotifications ? 'var(--offer)' : 'var(--border-card)'}` }}
+          className="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold uppercase tracking-wider transition-all w-full disabled:opacity-40 font-display color-ink"
+          style={{ background: emailNotifications ? 'rgba(58,106,74,0.1)' : 'var(--card)', border: `1px solid ${emailNotifications ? 'var(--offer)' : 'var(--border-card)'}` }}
         >
-          {emailNotifications ? <Bell className="w-4 h-4" style={{ color: 'var(--offer)' }} /> : <BellOff className="w-4 h-4" />}
+          {emailNotifications ? <Bell className="w-4 h-4 color-offer" /> : <BellOff className="w-4 h-4" />}
           Email notifications {emailNotifications ? 'on' : 'off'}
         </button>
       </div>
 
       {/* Sign out */}
-      <div className="mt-4 pt-4" style={{ borderTop: '1px solid var(--border)' }}>
-        <button onClick={signOut} className="inline-flex items-center gap-2 text-xs transition-colors"
-          style={{ color: 'var(--ink-muted)' }}>
+      <div className="mt-4 pt-4 border-t-theme">
+        <button onClick={signOut} className="inline-flex items-center gap-2 text-xs transition-colors color-ink-muted">
           <LogOut className="w-4 h-4" /> Sign out
         </button>
       </div>

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -26,13 +26,13 @@ export default async function AccountPage() {
   const vouchCount = profile?.vouch_count || 0;
 
   return (
-    <main className="min-h-screen" style={{ background: 'var(--bg)' }}>
+    <main className="min-h-screen bg-page">
       <header className="sticky top-0 z-40 backdrop-blur-xl border-b" style={{ background: 'rgba(26,42,32,0.9)', borderColor: 'var(--border)' }}>
         <div className="max-w-xl mx-auto px-5 flex items-center justify-between" style={{ height: '3.25rem' }}>
-          <Link href="/" className="inline-flex items-center gap-2 text-xs" style={{ color: 'var(--sub)' }}>
+          <Link href="/" className="inline-flex items-center gap-2 text-xs color-sub">
             <ArrowLeft className="w-4 h-4" /> Flourish
           </Link>
-          <span className="text-xs" style={{ color: 'var(--sub)', fontFamily: 'var(--font-display)' }}>
+          <span className="text-xs font-display color-sub">
             {user.email}
           </span>
         </div>
@@ -40,11 +40,10 @@ export default async function AccountPage() {
 
       <div className="max-w-xl mx-auto px-5 py-8">
         <div className="mb-8">
-          <h1 className="text-3xl font-extrabold uppercase tracking-wide mb-1"
-            style={{ fontFamily: 'var(--font-display)', color: 'var(--heading)' }}>
+          <h1 className="text-3xl font-extrabold uppercase tracking-wide mb-1 font-display color-heading">
             Your posts
           </h1>
-          <p className="text-sm italic" style={{ fontFamily: 'var(--font-serif)', color: 'var(--sub)' }}>
+          <p className="text-sm italic font-serif color-sub">
             {posts?.length || 0} {posts?.length === 1 ? 'post' : 'posts'} from you
           </p>
         </div>
@@ -53,20 +52,20 @@ export default async function AccountPage() {
         {vouchStatus === 'unvouched' && (
           <div className="mb-6 px-4 py-4" style={{ background: 'rgba(208,112,64,0.1)', border: '1px solid var(--need)' }}>
             <div className="flex items-center gap-2 mb-2">
-              <Shield className="w-4 h-4" style={{ color: 'var(--need)' }} />
-              <span className="text-xs font-bold uppercase tracking-wider" style={{ fontFamily: 'var(--font-display)', color: 'var(--need)' }}>
+              <Shield className="w-4 h-4 color-need" />
+              <span className="text-xs font-bold uppercase tracking-wider font-display color-need">
                 Not yet vouched
               </span>
             </div>
-            <p className="text-xs" style={{ fontFamily: 'var(--font-serif)', color: 'var(--sub)' }}>
+            <p className="text-xs font-serif color-sub">
               You need a vouch from an existing member to post or respond. Ask someone in the community, or use an invite link.
             </p>
           </div>
         )}
         {vouchStatus !== 'unvouched' && (
           <div className="mb-6 px-4 py-3 flex items-center gap-2" style={{ background: 'rgba(58,106,74,0.1)', border: '1px solid var(--offer)' }}>
-            <Shield className="w-4 h-4" style={{ color: 'var(--offer)' }} />
-            <span className="text-xs font-bold uppercase tracking-wider" style={{ fontFamily: 'var(--font-display)', color: 'var(--offer)' }}>
+            <Shield className="w-4 h-4 color-offer" />
+            <span className="text-xs font-bold uppercase tracking-wider font-display color-offer">
               Trusted member {vouchCount > 0 ? `· ${vouchCount} vouch${vouchCount > 1 ? 'es' : ''}` : ''}
             </span>
           </div>

--- a/src/app/account/profile/profile-form.tsx
+++ b/src/app/account/profile/profile-form.tsx
@@ -5,9 +5,6 @@ import { createClient } from '@/lib/supabase/client';
 import { useRouter } from 'next/navigation';
 import { Check } from 'lucide-react';
 
-const ds = { fontFamily: 'var(--font-display)' };
-const sr = { fontFamily: 'var(--font-serif)' };
-
 const NEIGHBOURHOODS = [
   'Old East Village', 'Wortley Village', 'Downtown', 'Old North',
   'Byron', 'Westmount', 'Masonville', 'Whitehills', 'Argyle',
@@ -75,8 +72,7 @@ export function ProfileForm({
       <div className="space-y-6">
         {/* Display Name */}
         <div>
-          <label className="block text-xs font-bold uppercase tracking-wider mb-2"
-            style={{ ...ds, color: 'var(--sub)', fontSize: '0.6rem' }}>
+          <label className="block text-xs font-bold uppercase tracking-wider mb-2 font-display color-sub" style={{ fontSize: '0.6rem' }}>
             Display name *
           </label>
           <input
@@ -92,8 +88,7 @@ export function ProfileForm({
 
         {/* Neighbourhood */}
         <div>
-          <label className="block text-xs font-bold uppercase tracking-wider mb-2"
-            style={{ ...ds, color: 'var(--sub)', fontSize: '0.6rem' }}>
+          <label className="block text-xs font-bold uppercase tracking-wider mb-2 font-display color-sub" style={{ fontSize: '0.6rem' }}>
             Neighbourhood
           </label>
           <select
@@ -122,8 +117,7 @@ export function ProfileForm({
 
         {/* Bio */}
         <div>
-          <label className="block text-xs font-bold uppercase tracking-wider mb-2"
-            style={{ ...ds, color: 'var(--sub)', fontSize: '0.6rem' }}>
+          <label className="block text-xs font-bold uppercase tracking-wider mb-2 font-display color-sub" style={{ fontSize: '0.6rem' }}>
             Bio
           </label>
           <textarea
@@ -135,22 +129,22 @@ export function ProfileForm({
             style={inputStyle}
             placeholder="A little about you (optional)"
           />
-          <p className="text-xs mt-1 text-right" style={{ color: 'var(--ink-muted)' }}>
+          <p className="text-xs mt-1 text-right color-ink-muted">
             {bio.length}/280
           </p>
         </div>
 
         {/* Error */}
         {error && (
-          <p className="text-sm" style={{ color: 'var(--need)' }}>{error}</p>
+          <p className="text-sm color-need">{error}</p>
         )}
 
         {/* Submit */}
         <button
           type="submit"
           disabled={saving}
-          className="inline-flex items-center gap-2 px-6 py-3 text-xs font-bold uppercase tracking-wider transition-all disabled:opacity-40"
-          style={{ ...ds, background: saved ? 'var(--offer)' : 'var(--card)', color: saved ? 'var(--card)' : 'var(--ink)', border: `1.5px solid ${saved ? 'var(--offer)' : 'var(--border-card)'}` }}
+          className="inline-flex items-center gap-2 px-6 py-3 text-xs font-bold uppercase tracking-wider transition-all disabled:opacity-40 font-display"
+          style={{ background: saved ? 'var(--offer)' : 'var(--card)', color: saved ? 'var(--card)' : 'var(--ink)', border: `1.5px solid ${saved ? 'var(--offer)' : 'var(--border-card)'}` }}
         >
           {saved ? <><Check className="w-4 h-4" /> Saved</> : saving ? 'Saving...' : 'Save profile'}
         </button>

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -19,10 +19,10 @@ export default async function AuthPage({
   }
 
   return (
-    <main className="min-h-screen flex flex-col" style={{ background: 'var(--bg)' }}>
+    <main className="min-h-screen flex flex-col bg-page">
       <header className="sticky top-0 z-40 backdrop-blur-xl border-b" style={{ background: 'rgba(26,42,32,0.9)', borderColor: 'var(--border)' }}>
         <div className="max-w-xl mx-auto px-5 flex items-center" style={{ height: "156px" }}>
-          <Link href="/" className="inline-flex items-center gap-2 text-xs" style={{ color: 'var(--sub)' }}>
+          <Link href="/" className="inline-flex items-center gap-2 text-xs color-sub">
             <ArrowLeft className="w-4 h-4" /> Back
           </Link>
         </div>
@@ -31,11 +31,10 @@ export default async function AuthPage({
       <div className="flex-1 flex items-center justify-center px-5 py-12">
         <div className="w-full max-w-sm">
           <div className="text-center mb-10">
-            <h1 className="text-4xl font-extrabold uppercase tracking-wide mb-2"
-              style={{ fontFamily: 'var(--font-display)', color: 'var(--heading)' }}>
+            <h1 className="text-4xl font-extrabold uppercase tracking-wide mb-2 font-display color-heading">
               Flourish
             </h1>
-            <p className="text-sm italic" style={{ fontFamily: 'var(--font-serif)', color: 'var(--sub)' }}>
+            <p className="text-sm italic font-serif color-sub">
               Sign in to manage your posts
             </p>
           </div>

--- a/src/app/code-of-conduct/page.tsx
+++ b/src/app/code-of-conduct/page.tsx
@@ -8,11 +8,8 @@ export const metadata = {
 };
 
 export default function CodeOfConductPage() {
-  const ds: React.CSSProperties = { fontFamily: 'var(--font-display)' };
-  const sr: React.CSSProperties = { fontFamily: 'var(--font-serif)' };
-
   return (
-    <main className="min-h-screen" style={{ background: 'var(--bg)' }}>
+    <main className="min-h-screen bg-page">
       <Header />
 
       <div className="max-w-2xl mx-auto px-5 py-14">
@@ -20,20 +17,18 @@ export default function CodeOfConductPage() {
         {/* Hero */}
         <div className="mb-12 text-center">
           <p
-            className="text-xs font-bold uppercase tracking-widest mb-3"
-            style={{ ...ds, color: 'var(--sub)' }}
+            className="text-xs font-bold uppercase tracking-widest mb-3 font-display color-sub"
           >
             Community guidelines
           </p>
           <h1
-            className="text-5xl sm:text-6xl font-extrabold uppercase tracking-wide leading-none mb-4"
-            style={{ ...ds, color: 'var(--heading)' }}
+            className="text-5xl sm:text-6xl font-extrabold uppercase tracking-wide leading-none mb-4 font-display color-heading"
           >
             Code of Conduct
           </h1>
           <p
-            className="text-lg leading-relaxed"
-            style={{ ...sr, color: 'var(--sub)', fontStyle: 'italic' }}
+            className="text-lg leading-relaxed font-serif color-sub"
+            style={{ fontStyle: 'italic' }}
           >
             How we show up for each other.
           </p>
@@ -46,20 +41,17 @@ export default function CodeOfConductPage() {
         >
           <div className="tape tape-offer" />
           <h2
-            className="text-xs font-bold uppercase tracking-widest mb-4"
-            style={{ ...ds, color: 'var(--offer)' }}
+            className="text-xs font-bold uppercase tracking-widest mb-4 font-display color-offer"
           >
             Our foundation
           </h2>
           <p
-            className="text-base leading-relaxed mb-4"
-            style={{ ...sr, color: 'var(--ink)' }}
+            className="text-base leading-relaxed mb-4 font-serif color-ink"
           >
             {APP_NAME} is built on mutual aid — the idea that we are stronger when we support each other. These guidelines exist to keep this space safe, respectful, and welcoming for everyone.
           </p>
           <p
-            className="text-base leading-relaxed italic"
-            style={{ ...sr, color: 'var(--ink-light)' }}
+            className="text-base leading-relaxed italic font-serif color-ink-light"
           >
             &ldquo;Solidarity, not charity. Asking is as important as giving.&rdquo; — Dean Spade
           </p>
@@ -72,8 +64,7 @@ export default function CodeOfConductPage() {
         >
           <div className="tape tape-need" />
           <h2
-            className="text-xs font-bold uppercase tracking-widest mb-5"
-            style={{ ...ds, color: 'var(--need)' }}
+            className="text-xs font-bold uppercase tracking-widest mb-5 font-display color-need"
           >
             Our principles
           </h2>
@@ -106,14 +97,12 @@ export default function CodeOfConductPage() {
             ].map((item) => (
               <div key={item.title}>
                 <h3
-                  className="text-sm font-bold uppercase tracking-wide mb-1"
-                  style={{ ...ds, color: 'var(--ink)' }}
+                  className="text-sm font-bold uppercase tracking-wide mb-1 font-display color-ink"
                 >
                   {item.title}
                 </h3>
                 <p
-                  className="text-base leading-relaxed"
-                  style={{ ...sr, color: 'var(--ink-light)' }}
+                  className="text-base leading-relaxed font-serif color-ink-light"
                 >
                   {item.body}
                 </p>
@@ -129,8 +118,7 @@ export default function CodeOfConductPage() {
         >
           <div className="tape tape-offer" style={{ left: '35%' }} />
           <h2
-            className="text-xs font-bold uppercase tracking-widest mb-5"
-            style={{ ...ds, color: 'var(--sub)' }}
+            className="text-xs font-bold uppercase tracking-widest mb-5 font-display color-sub"
           >
             What&apos;s not okay
           </h2>
@@ -144,8 +132,8 @@ export default function CodeOfConductPage() {
               'Using this space to recruit for political campaigns, MLMs, or religious proselytizing',
             ].map((item, i) => (
               <li key={i} className="flex items-start gap-2">
-                <span style={{ color: 'var(--need)', flexShrink: 0, marginTop: '0.125rem' }}>✗</span>
-                <p className="text-base leading-relaxed" style={{ ...sr, color: 'var(--ink-light)' }}>{item}</p>
+                <span className="color-need" style={{ flexShrink: 0, marginTop: '0.125rem' }}>✗</span>
+                <p className="text-base leading-relaxed font-serif color-ink-light">{item}</p>
               </li>
             ))}
           </ul>
@@ -158,14 +146,12 @@ export default function CodeOfConductPage() {
         >
           <div className="tape tape-need" style={{ left: '45%' }} />
           <h2
-            className="text-xs font-bold uppercase tracking-widest mb-4"
-            style={{ ...ds, color: 'var(--need)' }}
+            className="text-xs font-bold uppercase tracking-widest mb-4 font-display color-need"
           >
             When someone needs more support
           </h2>
           <p
-            className="text-base leading-relaxed"
-            style={{ ...sr, color: 'var(--ink-light)' }}
+            className="text-base leading-relaxed font-serif color-ink-light"
           >
             If someone is asking for essential items repeatedly, we reach out with care — not judgement. We connect them with resources that can help long-term, like{' '}
             local community services and organizations. Mutual aid is a bridge, not a replacement for systemic support.
@@ -179,20 +165,17 @@ export default function CodeOfConductPage() {
         >
           <div className="tape tape-offer" style={{ left: '30%' }} />
           <h2
-            className="text-xs font-bold uppercase tracking-widest mb-4"
-            style={{ ...ds, color: 'var(--sub)' }}
+            className="text-xs font-bold uppercase tracking-widest mb-4 font-display color-sub"
           >
             Moderation
           </h2>
           <p
-            className="text-base leading-relaxed mb-3"
-            style={{ ...sr, color: 'var(--ink-light)' }}
+            className="text-base leading-relaxed mb-3 font-serif color-ink-light"
           >
             {APP_NAME} is moderated by volunteers from the community. When someone violates these guidelines, we start with conversation and education. We believe in accountability and making amends.
           </p>
           <p
-            className="text-base leading-relaxed"
-            style={{ ...sr, color: 'var(--ink-light)' }}
+            className="text-base leading-relaxed font-serif color-ink-light"
           >
             Repeated violations or severe harm (hate speech, threats, harassment) may result in removal. We have no tolerance for intolerance.
           </p>
@@ -205,14 +188,12 @@ export default function CodeOfConductPage() {
         >
           <div className="tape tape-need" style={{ left: '40%' }} />
           <h2
-            className="text-xs font-bold uppercase tracking-widest mb-4"
-            style={{ ...ds, color: 'var(--need)' }}
+            className="text-xs font-bold uppercase tracking-widest mb-4 font-display color-need"
           >
             A living document
           </h2>
           <p
-            className="text-base leading-relaxed"
-            style={{ ...sr, color: 'var(--ink-light)' }}
+            className="text-base leading-relaxed font-serif color-ink-light"
           >
             This code of conduct was written collaboratively by the people building {APP_NAME}. It will grow and change as we do. If you have suggestions, we want to hear them.
           </p>
@@ -222,16 +203,15 @@ export default function CodeOfConductPage() {
         <div className="text-center space-y-4">
           <Link
             href="/"
-            className="inline-block px-10 py-4 text-sm font-bold uppercase tracking-wider transition-colors"
-            style={{ ...ds, background: 'var(--card)', color: 'var(--ink)' }}
+            className="inline-block px-10 py-4 text-sm font-bold uppercase tracking-wider transition-colors font-display"
+            style={{ background: 'var(--card)', color: 'var(--ink)' }}
           >
             Browse the board
           </Link>
           <div>
             <Link
               href="/feedback"
-              className="text-xs font-bold uppercase tracking-wider"
-              style={{ ...ds, color: 'var(--sub)' }}
+              className="text-xs font-bold uppercase tracking-wider font-display color-sub"
             >
               Send feedback →
             </Link>

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -12,9 +12,6 @@ export default function FeedbackPage() {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState('');
 
-  const ds: React.CSSProperties = { fontFamily: 'var(--font-display)' };
-  const sr: React.CSSProperties = { fontFamily: 'var(--font-serif)' };
-
   const inputStyle: React.CSSProperties = {
     background: 'var(--card)',
     border: '1px solid var(--border-card)',
@@ -24,17 +21,6 @@ export default function FeedbackPage() {
     fontSize: '0.9rem',
     fontFamily: 'var(--font-body)',
     outline: 'none',
-  };
-
-  const labelStyle: React.CSSProperties = {
-    display: 'block',
-    fontSize: '0.6rem',
-    fontWeight: 700,
-    textTransform: 'uppercase',
-    letterSpacing: '0.12em',
-    color: 'var(--sub)',
-    marginBottom: '0.375rem',
-    ...ds,
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -64,7 +50,7 @@ export default function FeedbackPage() {
   };
 
   return (
-    <main className="min-h-screen" style={{ background: 'var(--bg)' }}>
+    <main className="min-h-screen bg-page">
       <Header />
 
       <div className="flex-1 flex items-start justify-center px-5 py-14">
@@ -72,20 +58,18 @@ export default function FeedbackPage() {
 
           <div className="mb-10">
             <p
-              className="text-xs font-bold uppercase tracking-widest mb-2"
-              style={{ ...ds, color: 'var(--sub)' }}
+              className="text-xs font-bold uppercase tracking-widest mb-2 font-display color-sub"
             >
               Community
             </p>
             <h1
-              className="text-4xl font-extrabold uppercase tracking-wide leading-none mb-3"
-              style={{ ...ds, color: 'var(--heading)' }}
+              className="text-4xl font-extrabold uppercase tracking-wide leading-none mb-3 font-display color-heading"
             >
               Feedback
             </h1>
             <p
-              className="text-sm leading-relaxed"
-              style={{ ...sr, color: 'var(--sub)', fontStyle: 'italic' }}
+              className="text-sm leading-relaxed font-serif color-sub"
+              style={{ fontStyle: 'italic' }}
             >
               Got a thought, a bug report, or a suggestion? We&apos;d love to hear it.
             </p>
@@ -97,21 +81,19 @@ export default function FeedbackPage() {
               style={{ background: 'var(--card)', border: '1px solid var(--border)' }}
             >
               <div
-                className="text-2xl font-extrabold uppercase tracking-wide mb-3"
-                style={{ ...ds, color: 'var(--offer)' }}
+                className="text-2xl font-extrabold uppercase tracking-wide mb-3 font-display color-offer"
               >
                 Thank you
               </div>
               <p
-                className="text-sm leading-relaxed mb-6"
-                style={{ ...sr, color: 'var(--ink-light)', fontStyle: 'italic' }}
+                className="text-sm leading-relaxed mb-6 font-serif color-ink-light"
+                style={{ fontStyle: 'italic' }}
               >
                 Your message has been sent. We read every piece of feedback.
               </p>
               <Link
                 href="/"
-                className="inline-block px-6 py-3 text-xs font-bold uppercase tracking-wider"
-                style={{ ...ds, background: 'var(--ink)', color: 'var(--card)' }}
+                className="inline-block px-6 py-3 text-xs font-bold uppercase tracking-wider font-display btn-ink"
               >
                 Back to the board
               </Link>
@@ -123,8 +105,8 @@ export default function FeedbackPage() {
             >
               <form onSubmit={handleSubmit} className="space-y-5">
                 <div>
-                  <label style={labelStyle}>
-                    Name <span style={{ color: 'var(--ink-muted)' }}>(optional)</span>
+                  <label className="form-label">
+                    Name <span className="color-ink-muted normal-case tracking-normal font-normal">(optional)</span>
                   </label>
                   <input
                     type="text"
@@ -136,8 +118,8 @@ export default function FeedbackPage() {
                 </div>
 
                 <div>
-                  <label style={labelStyle}>
-                    Email <span style={{ color: 'var(--ink-muted)' }}>(optional — if you want a reply)</span>
+                  <label className="form-label">
+                    Email <span className="color-ink-muted normal-case tracking-normal font-normal">(optional — if you want a reply)</span>
                   </label>
                   <input
                     type="email"
@@ -149,8 +131,8 @@ export default function FeedbackPage() {
                 </div>
 
                 <div>
-                  <label style={labelStyle}>
-                    Message <span style={{ color: 'var(--need)' }}>*</span>
+                  <label className="form-label">
+                    Message <span className="color-need">*</span>
                   </label>
                   <textarea
                     value={message}
@@ -182,8 +164,7 @@ export default function FeedbackPage() {
                 <button
                   type="submit"
                   disabled={loading || !message.trim()}
-                  className="w-full py-3.5 text-sm font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
-                  style={{ ...ds, background: 'var(--ink)', color: 'var(--card)' }}
+                  className="w-full py-3.5 text-sm font-bold uppercase tracking-wider disabled:opacity-40 transition-all font-display btn-ink"
                 >
                   {loading ? 'Sending…' : 'Send feedback'}
                 </button>
@@ -192,10 +173,10 @@ export default function FeedbackPage() {
           )}
 
           <p
-            className="text-xs text-center mt-6"
-            style={{ ...ds, color: 'var(--ink-muted)', letterSpacing: '0.08em' }}
+            className="text-xs text-center mt-6 font-display color-ink-muted"
+            style={{ letterSpacing: '0.08em' }}
           >
-            <Link href="/" style={{ color: 'var(--sub)' }}>Back to the board</Link>
+            <Link href="/" className="color-sub">Back to the board</Link>
           </p>
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -459,3 +459,41 @@
 .font-preview-nunito { font-family: 'Nunito', system-ui, sans-serif; }
 .font-preview-source-serif { font-family: 'Source Serif 4', Georgia, serif; }
 .font-preview-merriweather { font-family: 'Merriweather', Georgia, serif; }
+
+/* Utility classes for inline style replacement */
+.font-display { font-family: var(--font-display); }
+.font-serif { font-family: var(--font-serif); }
+.font-body { font-family: var(--font-body); }
+.bg-page { background: var(--bg); }
+.bg-card { background: var(--card); }
+.bg-card-hover { background: var(--card-hover); }
+.bg-alpha { background: var(--bg-alpha); }
+.border-theme { border: 1px solid var(--border); }
+.border-card { border: 1px solid var(--border-card); }
+.border-dashed-theme { border: 1px dashed var(--border); }
+.border-t-theme { border-top: 1px solid var(--border); }
+.border-b-theme { border-bottom: 1px solid var(--border); }
+.color-heading { color: var(--heading); }
+.color-ink { color: var(--ink); }
+.color-ink-light { color: var(--ink-light); }
+.color-ink-muted { color: var(--ink-muted); }
+.color-sub { color: var(--sub); }
+.color-need { color: var(--need); }
+.color-offer { color: var(--offer); }
+.color-card { color: var(--card); }
+.bg-need { background: var(--need); }
+.bg-offer { background: var(--offer); }
+.header-blur { background: var(--bg-alpha); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); }
+.label-sm { font-family: var(--font-display); font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em; color: var(--sub); }
+.label-xs { font-family: var(--font-display); font-size: 0.55rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; }
+.form-input { background: var(--bg-light); border: 1px solid var(--border); color: var(--heading); padding: 10px 14px; font-size: 0.85rem; font-family: var(--font-body); outline: none; width: 100%; }
+.form-input:focus { border-color: var(--offer); }
+.form-label { display: block; font-family: var(--font-display); font-size: 0.6rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em; color: var(--sub); margin-bottom: 0.3125rem; }
+.form-textarea { background: var(--bg-light); border: 1px solid var(--border); color: var(--heading); padding: 10px 14px; font-size: 0.85rem; font-family: var(--font-body); outline: none; width: 100%; min-height: 120px; resize: vertical; }
+.btn-need { background: var(--need); color: var(--card); font-family: var(--font-display); }
+.btn-offer { background: var(--offer); color: var(--card); font-family: var(--font-display); }
+.btn-outline { background: transparent; border: 1px solid var(--border); color: var(--sub); font-family: var(--font-display); }
+.btn-ink { background: var(--ink); color: var(--card); font-family: var(--font-display); }
+.card-theme { background: var(--card); border: 1px solid var(--border); }
+.glow-need { background: radial-gradient(ellipse 80% 40% at 50% 0%, rgba(208,112,64,0.12) 0%, transparent 70%); }
+.glow-offer { background: radial-gradient(ellipse 80% 40% at 50% 0%, rgba(58,106,74,0.18) 0%, transparent 70%); }

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -16,16 +16,16 @@ export default async function MapPage() {
     .order('created_at', { ascending: false });
 
   return (
-    <main className="min-h-screen flex flex-col" style={{ background: 'var(--bg)' }}>
+    <main className="min-h-screen flex flex-col bg-page">
       <header className="sticky top-0 z-40 backdrop-blur-xl border-b" style={{ background: 'rgba(26,42,32,0.9)', borderColor: 'var(--border)' }}>
         <div className="max-w-xl mx-auto px-5 flex items-center justify-between" style={{ height: '3.25rem' }}>
-          <Link href="/" className="inline-flex items-center gap-2 text-xs" style={{ color: 'var(--sub)' }}>
+          <Link href="/" className="inline-flex items-center gap-2 text-xs color-sub">
             <ArrowLeft className="w-4 h-4" /> Back
           </Link>
-          <span className="text-xs font-bold uppercase tracking-widest" style={{ color: 'var(--heading)', fontFamily: 'var(--font-display)' }}>
+          <span className="text-xs font-bold uppercase tracking-widest font-display color-heading">
             Map view
           </span>
-          <span className="text-xs" style={{ color: 'var(--sub)' }}>{posts?.length || 0} posts</span>
+          <span className="text-xs color-sub">{posts?.length || 0} posts</span>
         </div>
       </header>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,27 +29,25 @@ export default async function Home() {
     .or('moderation_status.eq.approved,moderation_status.is.null');
 
   return (
-    <main className="min-h-screen" style={{ background: 'var(--bg)' }}>
+    <main className="min-h-screen bg-page">
       <Header />
 
       {/* Hero */}
       <section className="text-center px-5 pt-12 pb-8">
         <h1
-          className="text-5xl sm:text-6xl font-extrabold uppercase tracking-wide leading-none mb-2"
-          style={{ color: 'var(--heading)', fontFamily: 'var(--font-display)' }}
+          className="text-5xl sm:text-6xl font-extrabold uppercase tracking-wide leading-none mb-2 font-display color-heading"
         >
           {APP_NAME}
         </h1>
         <p
-          className="text-base sm:text-xl mb-6"
-          style={{ color: 'var(--sub)', fontFamily: 'var(--font-serif)' }}
+          className="text-base sm:text-xl mb-6 font-serif color-sub"
         >
           {APP_DESCRIPTION}
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3 mt-2">
           <PostSomethingButton />
-          <a href="/map" className="px-8 py-3 text-sm font-bold uppercase tracking-wider transition-colors"
-            style={{ border: '1.5px solid rgba(232,224,204,0.2)', color: 'var(--heading)', fontFamily: 'var(--font-display)' }}>
+          <a href="/map" className="px-8 py-3 text-sm font-bold uppercase tracking-wider transition-colors font-display color-heading"
+            style={{ border: '1.5px solid rgba(232,224,204,0.2)' }}>
             View map
           </a>
         </div>

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -31,7 +31,7 @@ export default async function PostDetail({ params }: { params: { id: string } })
     }}>
       <header className="sticky top-0 z-40 backdrop-blur-xl border-b" style={{ background: 'rgba(26,42,32,0.9)', borderColor: 'var(--border)' }}>
         <div className="max-w-xl mx-auto px-5 flex items-center" style={{ height: "156px" }}>
-          <Link href="/" className="inline-flex items-center gap-2 text-xs" style={{ color: 'var(--sub)' }}>
+          <Link href="/" className="inline-flex items-center gap-2 text-xs color-sub">
             <ArrowLeft className="w-4 h-4" /> Back
           </Link>
         </div>
@@ -47,22 +47,22 @@ export default async function PostDetail({ params }: { params: { id: string } })
         )}
 
         {/* Type */}
-        <div className="text-xs font-bold uppercase tracking-wider mb-3" style={{ fontFamily: 'var(--font-display)', color: isNeed ? 'var(--need)' : 'var(--offer)', fontSize: '0.65rem', letterSpacing: '0.15em' }}>
+        <div className="text-xs font-bold uppercase tracking-wider mb-3 font-display" style={{ color: isNeed ? 'var(--need)' : 'var(--offer)', fontSize: '0.65rem', letterSpacing: '0.15em' }}>
           {isNeed ? 'Need' : 'Offer'}
         </div>
 
         {/* Title */}
-        <h1 className="text-2xl sm:text-3xl leading-tight mb-4" style={{ fontFamily: 'var(--font-serif)', color: 'var(--heading)', fontWeight: 400 }}>
+        <h1 className="text-2xl sm:text-3xl leading-tight mb-4 font-serif color-heading" style={{ fontWeight: 400 }}>
           {post.title}
         </h1>
 
         {/* Meta */}
-        <div className="flex flex-wrap items-center gap-2 text-xs mb-6" style={{ color: 'var(--sub)', fontSize: '0.72rem' }}>
+        <div className="flex flex-wrap items-center gap-2 text-xs mb-6 color-sub" style={{ fontSize: '0.72rem' }}>
           <span style={{ fontWeight: 500, color: 'var(--heading)' }}>{(post as any).profiles?.display_name || post.contact_name}</span>
           {(post as any).profiles?.neighbourhood && (
             <>
               <span>&mdash;</span>
-              <span style={{ color: 'var(--offer)', fontFamily: 'var(--font-display)', fontSize: '0.6rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+              <span className="font-display color-offer" style={{ fontSize: '0.6rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
                 {(post as any).profiles.neighbourhood}
               </span>
             </>
@@ -81,16 +81,16 @@ export default async function PostDetail({ params }: { params: { id: string } })
         {/* Details */}
         {post.details && (
           <div className="mb-8">
-            <p className="text-sm leading-relaxed whitespace-pre-wrap" style={{ color: 'var(--heading)' }}>{post.details}</p>
+            <p className="text-sm leading-relaxed whitespace-pre-wrap color-heading">{post.details}</p>
           </div>
         )}
 
         {/* Contact info (if public method chosen) */}
         {post.contact_method !== 'app' && post.contact_value && (
           <div className="mb-8 p-4" style={{ background: 'rgba(240,236,224,0.08)', border: '1px dashed var(--border)' }}>
-            <p className="text-xs font-bold uppercase tracking-wider mb-2" style={{ fontFamily: 'var(--font-display)', color: 'var(--sub)', fontSize: '0.6rem' }}>Contact</p>
-            <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--heading)' }}>
-              {post.contact_method === 'phone' ? <><Phone className="w-4 h-4" style={{ color: 'var(--sub)' }} /><a href={`tel:${post.contact_value}`}>{post.contact_value}</a></> : <><Mail className="w-4 h-4" style={{ color: 'var(--sub)' }} /><a href={`mailto:${post.contact_value}`}>{post.contact_value}</a></>}
+            <p className="text-xs font-bold uppercase tracking-wider mb-2 font-display color-sub" style={{ fontSize: '0.6rem' }}>Contact</p>
+            <div className="flex items-center gap-2 text-sm color-heading">
+              {post.contact_method === 'phone' ? <><Phone className="w-4 h-4 color-sub" /><a href={`tel:${post.contact_value}`}>{post.contact_value}</a></> : <><Mail className="w-4 h-4 color-sub" /><a href={`mailto:${post.contact_value}`}>{post.contact_value}</a></>}
             </div>
           </div>
         )}

--- a/src/app/post/[id]/post-detail-client.tsx
+++ b/src/app/post/[id]/post-detail-client.tsx
@@ -77,28 +77,25 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
     setThreading(null);
   };
 
-  const ds = { fontFamily: 'var(--font-display)' } as React.CSSProperties;
-  const sr = { fontFamily: 'var(--font-serif)' } as React.CSSProperties;
-
   return (
     <>
       {/* Respond button — shown to non-posters, vouched users only */}
       {!isPoster && post.status === 'active' && (
         <div className="mb-8">
           {currentUserId && vouchRequired && vouchStatus === 'unvouched' ? (
-            <div className="w-full py-4 px-4 text-center text-sm" style={{ background: 'rgba(240,236,224,0.08)', border: '1px dashed var(--border)' }}>
-              <p className="text-xs font-bold uppercase tracking-wider mb-1" style={{ ...ds, color: 'var(--sub)' }}>
+            <div className="w-full py-4 px-4 text-center text-sm border-dashed-theme" style={{ background: 'rgba(240,236,224,0.08)' }}>
+              <p className="text-xs font-bold uppercase tracking-wider mb-1 font-display color-sub">
                 Vouch needed to respond
               </p>
-              <p className="text-xs" style={{ color: 'var(--ink-muted)', fontFamily: 'var(--font-serif)' }}>
-                Ask a member to vouch for you, or <a href="/join" style={{ color: 'var(--offer)', textDecoration: 'underline' }}>use an invite link</a>
+              <p className="text-xs font-serif color-ink-muted">
+                Ask a member to vouch for you, or <a href="/join" className="color-offer" style={{ textDecoration: 'underline' }}>use an invite link</a>
               </p>
             </div>
           ) : (
             <button
               onClick={() => currentUserId ? setShowRespond(true) : window.location.assign('/auth?next=/post/' + post.id)}
-              className="w-full py-4 text-sm font-bold uppercase tracking-wider transition-all"
-              style={{ ...ds, background: isNeed ? 'var(--need)' : 'var(--offer)', color: 'var(--card)' }}
+              className="w-full py-4 text-sm font-bold uppercase tracking-wider transition-all font-display color-card"
+              style={{ background: isNeed ? 'var(--need)' : 'var(--offer)' }}
             >
               {isNeed ? 'I can help with this' : 'I\'m interested in this'}
             </button>
@@ -113,16 +110,16 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
           style={{ border: '1px dashed rgba(208,112,64,0.4)', background: 'rgba(208,112,64,0.04)' }}
         >
           <div
-            className="text-xs font-bold uppercase tracking-wider mb-3"
-            style={{ ...ds, color: 'var(--need)', fontSize: '0.6rem', letterSpacing: '0.14em' }}
+            className="text-xs font-bold uppercase tracking-wider mb-3 font-display color-need"
+            style={{ fontSize: '0.6rem', letterSpacing: '0.14em' }}
           >
             Moderation
           </div>
 
           {modAction ? (
             <div
-              className="text-sm font-bold uppercase tracking-wider"
-              style={{ ...ds, color: modAction === 'approved' ? 'var(--offer)' : 'var(--need)' }}
+              className="text-sm font-bold uppercase tracking-wider font-display"
+              style={{ color: modAction === 'approved' ? 'var(--offer)' : 'var(--need)' }}
             >
               {modAction === 'approved' ? '✓ Approved' : '✕ Rejected'}
             </div>
@@ -146,15 +143,13 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
               <button
                 onClick={() => handleModerate('reject', rejectReason)}
                 disabled={moderating}
-                className="px-4 py-2 text-xs font-bold uppercase tracking-wider disabled:opacity-40"
-                style={{ ...ds, background: 'var(--need)', color: 'white' }}
+                className="px-4 py-2 text-xs font-bold uppercase tracking-wider disabled:opacity-40 font-display btn-need"
               >
                 {moderating ? '…' : 'Confirm Reject'}
               </button>
               <button
                 onClick={() => setShowRejectInput(false)}
-                className="text-xs"
-                style={{ color: 'var(--ink-muted)' }}
+                className="text-xs color-ink-muted"
               >
                 Cancel
               </button>
@@ -164,16 +159,16 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
               <button
                 onClick={() => handleModerate('approve')}
                 disabled={moderating}
-                className="px-5 py-2.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors"
-                style={{ ...ds, background: 'var(--offer)', color: 'white', letterSpacing: '0.1em' }}
+                className="px-5 py-2.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors font-display"
+                style={{ background: 'var(--offer)', color: 'white', letterSpacing: '0.1em' }}
               >
                 ✓ Approve
               </button>
               <button
                 onClick={() => setShowRejectInput(true)}
                 disabled={moderating}
-                className="px-5 py-2.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors"
-                style={{ ...ds, background: 'var(--need)', color: 'white', letterSpacing: '0.1em' }}
+                className="px-5 py-2.5 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors font-display"
+                style={{ background: 'var(--need)', color: 'white', letterSpacing: '0.1em' }}
               >
                 ✕ Reject
               </button>
@@ -185,28 +180,27 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
       {/* Responses — visible to all */}
       {post.responses && post.responses.length > 0 && (
         <div className="mt-8">
-          <h2 className="text-sm font-bold uppercase tracking-wide mb-4" style={{ ...ds, color: 'var(--heading)' }}>
+          <h2 className="text-sm font-bold uppercase tracking-wide mb-4 font-display color-heading">
             {post.responses.length} {post.responses.length === 1 ? 'Response' : 'Responses'}
           </h2>
           <div className="space-y-3">
             {post.responses.map((r: any) => (
               <div
                 key={r.id}
-                className="p-4"
-                style={{ background: 'var(--card)', border: '1px solid var(--border)' }}
+                className="p-4 card-theme"
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
-                      <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>
+                      <span className="text-sm font-medium color-ink">
                         {r.responder_name}
                       </span>
-                      <span className="text-xs" style={{ color: 'var(--ink-muted)' }}>
+                      <span className="text-xs color-ink-muted">
                         {formatDistanceToNow(new Date(r.created_at), { addSuffix: true })}
                       </span>
                     </div>
                     {r.message && (
-                      <p className="text-sm leading-relaxed" style={{ ...sr, color: 'var(--ink-light)', fontStyle: 'italic' }}>
+                      <p className="text-sm leading-relaxed font-serif color-ink-light" style={{ fontStyle: 'italic' }}>
                         &ldquo;{r.message}&rdquo;
                       </p>
                     )}
@@ -217,9 +211,8 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
                     <button
                       onClick={() => startThread(r.user_id)}
                       disabled={threading === r.user_id}
-                      className="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-xs font-bold uppercase tracking-wider transition-all disabled:opacity-40"
+                      className="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-2 text-xs font-bold uppercase tracking-wider transition-all disabled:opacity-40 font-display"
                       style={{
-                        ...ds,
                         fontSize: '0.6rem',
                         border: '1.5px solid var(--offer)',
                         color: 'var(--offer)',
@@ -246,7 +239,7 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
       )}
 
       {post.status === 'active' && post.responses.length === 0 && !isPoster && (
-        <p className="text-sm text-center italic mt-4" style={{ ...sr, color: 'var(--ink-muted)' }}>
+        <p className="text-sm text-center italic mt-4 font-serif color-ink-muted">
           No responses yet — be the first.
         </p>
       )}

--- a/src/components/create-post-form.tsx
+++ b/src/components/create-post-form.tsx
@@ -66,33 +66,30 @@ export function CreatePostForm({ onClose }: CreatePostFormProps) {
     setSubmitting(false);
   };
 
-  const ds = { fontFamily: 'var(--font-display)' };
-  const sr = { fontFamily: 'var(--font-serif)' };
-
   return (
     <div className="fixed inset-0 flex items-end sm:items-center justify-center z-50 animate-fade-in" style={{ background: 'rgba(0,0,0,0.5)' }} onClick={onClose}>
-      <div className="w-full max-w-lg max-h-[85vh] overflow-y-auto animate-slide-up sm:rounded-md" style={{ background: 'var(--card)' }} onClick={(e) => e.stopPropagation()}>
+      <div className="w-full max-w-lg max-h-[85vh] overflow-y-auto animate-slide-up sm:rounded-md bg-card" onClick={(e) => e.stopPropagation()}>
         {submitted ? (
           <div className="text-center py-20 px-6">
-            <p className="text-xl font-bold uppercase tracking-wide mb-3" style={{ ...ds, color: 'var(--ink)' }}>Shared with the community</p>
-            <p className="text-sm" style={{ color: 'var(--ink-muted)' }}>Your {type} is now live on the board.</p>
+            <p className="text-xl font-bold uppercase tracking-wide mb-3 font-display color-ink">Shared with the community</p>
+            <p className="text-sm color-ink-muted">Your {type} is now live on the board.</p>
           </div>
         ) : (
           <>
             {/* Header */}
             <div className="flex items-center justify-between px-6 pt-6 pb-2">
               <div className="flex items-center gap-3">
-                {step > 1 && <button onClick={() => setStep(step - 1)} className="p-1" style={{ color: 'var(--ink-muted)' }}><ArrowLeft className="w-4 h-4" /></button>}
+                {step > 1 && <button onClick={() => setStep(step - 1)} className="p-1 color-ink-muted"><ArrowLeft className="w-4 h-4" /></button>}
                 <div>
-                  <p className="text-xs" style={{ color: 'var(--ink-muted)', fontSize: '0.6rem', ...ds }}>Step {step} of 3</p>
-                  <p className="text-sm font-bold uppercase tracking-wide" style={{ ...ds, color: 'var(--ink)' }}>
+                  <p className="text-xs font-display color-ink-muted" style={{ fontSize: '0.6rem' }}>Step {step} of 3</p>
+                  <p className="text-sm font-bold uppercase tracking-wide font-display color-ink">
                     {step === 1 && 'What kind of post?'}
                     {step === 2 && (type === 'need' ? 'What do you need?' : 'What can you offer?')}
                     {step === 3 && 'About you'}
                   </p>
                 </div>
               </div>
-              <button onClick={onClose} className="p-2" style={{ color: 'var(--ink-muted)' }}><X className="w-5 h-5" /></button>
+              <button onClick={onClose} className="p-2 color-ink-muted"><X className="w-5 h-5" /></button>
             </div>
 
             {/* Progress */}
@@ -116,8 +113,8 @@ export function CreatePostForm({ onClose }: CreatePostFormProps) {
                         background: type === opt.val ? '#fff' : 'transparent',
                       }}
                     >
-                      <p className="text-sm font-bold uppercase tracking-wide" style={{ ...ds, color: 'var(--ink)' }}>{opt.label}</p>
-                      <p className="text-xs mt-1" style={{ ...sr, color: 'var(--ink-muted)', fontStyle: 'italic' }}>{opt.desc}</p>
+                      <p className="text-sm font-bold uppercase tracking-wide font-display color-ink">{opt.label}</p>
+                      <p className="text-xs mt-1 font-serif color-ink-muted" style={{ fontStyle: 'italic' }}>{opt.desc}</p>
                     </button>
                   ))}
                 </div>
@@ -126,37 +123,37 @@ export function CreatePostForm({ onClose }: CreatePostFormProps) {
               {step === 2 && (
                 <div className="space-y-5 animate-fade-up">
                   <input type="text" value={title} onChange={(e) => setTitle(e.target.value)}
-                    className="w-full px-0 py-3 bg-transparent border-0 border-b-2 focus:outline-none text-lg"
-                    style={{ borderColor: 'var(--border-card)', color: 'var(--ink)', ...sr }}
+                    className="w-full px-0 py-3 bg-transparent border-0 border-b-2 focus:outline-none text-lg font-serif color-ink"
+                    style={{ borderColor: 'var(--border-card)' }}
                     placeholder={type === 'need' ? 'Ride to appointment Tuesday' : 'Winter coats, kids sizes'}
                     autoFocus
                   />
                   <div>
-                    <label className="block text-xs font-bold uppercase tracking-wider mb-2" style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}>Details <span className="normal-case tracking-normal font-normal" style={{ color: 'var(--ink-muted)' }}>(optional)</span></label>
+                    <label className="block text-xs font-bold uppercase tracking-wider mb-2 font-display color-ink-light" style={{ fontSize: '0.6rem' }}>Details <span className="normal-case tracking-normal font-normal color-ink-muted">(optional)</span></label>
                     <textarea value={details} onChange={(e) => setDetails(e.target.value)}
-                      className="w-full px-4 py-3 text-sm focus:outline-none resize-none"
-                      style={{ background: '#fff', border: '1px solid var(--border-card)', color: 'var(--ink)' }}
+                      className="w-full px-4 py-3 text-sm focus:outline-none resize-none color-ink"
+                      style={{ background: '#fff', border: '1px solid var(--border-card)' }}
                       rows={3} placeholder="Any extra context..."
                     />
                   </div>
                   <div>
-                    <label className="block text-xs font-bold uppercase tracking-wider mb-2" style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}>Category</label>
+                    <label className="block text-xs font-bold uppercase tracking-wider mb-2 font-display color-ink-light" style={{ fontSize: '0.6rem' }}>Category</label>
                     <div className="flex gap-2 flex-wrap">
                       {CATEGORIES.map((c) => (
                         <button key={c.value} type="button" onClick={() => setCategory(c.value)}
-                          className="px-3 py-2 text-xs font-bold uppercase tracking-wider transition-all"
-                          style={{ ...ds, fontSize: '0.6rem', background: category === c.value ? 'var(--ink)' : 'transparent', color: category === c.value ? 'var(--card)' : 'var(--ink-light)', border: `1.5px solid ${category === c.value ? 'var(--ink)' : 'var(--border-card)'}` }}
+                          className="px-3 py-2 text-xs font-bold uppercase tracking-wider transition-all font-display"
+                          style={{ fontSize: '0.6rem', background: category === c.value ? 'var(--ink)' : 'transparent', color: category === c.value ? 'var(--card)' : 'var(--ink-light)', border: `1.5px solid ${category === c.value ? 'var(--ink)' : 'var(--border-card)'}` }}
                         >{c.label}</button>
                       ))}
                     </div>
                   </div>
                   <div>
-                    <label className="block text-xs font-bold uppercase tracking-wider mb-2" style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}>How soon?</label>
+                    <label className="block text-xs font-bold uppercase tracking-wider mb-2 font-display color-ink-light" style={{ fontSize: '0.6rem' }}>How soon?</label>
                     <div className="flex gap-2">
                       {URGENCIES.map((u) => (
                         <button key={u.value} type="button" onClick={() => setUrgency(u.value)}
-                          className="flex-1 px-3 py-2 text-xs font-bold uppercase tracking-wider text-center transition-all"
-                          style={{ ...ds, fontSize: '0.6rem', background: urgency === u.value ? 'var(--ink)' : 'transparent', color: urgency === u.value ? 'var(--card)' : 'var(--ink-light)', border: `1.5px solid ${urgency === u.value ? 'var(--ink)' : 'var(--border-card)'}` }}
+                          className="flex-1 px-3 py-2 text-xs font-bold uppercase tracking-wider text-center transition-all font-display"
+                          style={{ fontSize: '0.6rem', background: urgency === u.value ? 'var(--ink)' : 'transparent', color: urgency === u.value ? 'var(--card)' : 'var(--ink-light)', border: `1.5px solid ${urgency === u.value ? 'var(--ink)' : 'var(--border-card)'}` }}
                         >{u.label}</button>
                       ))}
                     </div>
@@ -164,25 +161,24 @@ export function CreatePostForm({ onClose }: CreatePostFormProps) {
 
                   {/* Location — cross-street only */}
                   <div>
-                    <label className="block text-xs font-bold uppercase tracking-wider mb-1" style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}>
-                      Whereabouts? <span className="normal-case tracking-normal font-normal" style={{ color: 'var(--ink-muted)' }}>(optional — places a pin on the map)</span>
+                    <label className="block text-xs font-bold uppercase tracking-wider mb-1 font-display color-ink-light" style={{ fontSize: '0.6rem' }}>
+                      Whereabouts? <span className="normal-case tracking-normal font-normal color-ink-muted">(optional — places a pin on the map)</span>
                     </label>
-                    <p className="text-xs mb-2" style={{ color: 'var(--ink-muted)', fontSize: '0.68rem' }}>
+                    <p className="text-xs mb-2 color-ink-muted" style={{ fontSize: '0.68rem' }}>
                       Use a nearby intersection for best results (neighbourhood names alone won&apos;t appear on the map). We never show your exact location — only an approximate area.
                     </p>
                     <input
                       type="text"
                       value={crossStreet}
                       onChange={(e) => setCrossStreet(e.target.value)}
-                      className="w-full px-4 py-3 text-sm focus:outline-none"
-                      style={{ background: '#fff', border: '1px solid var(--border-card)', color: 'var(--ink)' }}
+                      className="w-full px-4 py-3 text-sm focus:outline-none color-ink"
+                      style={{ background: '#fff', border: '1px solid var(--border-card)' }}
                       placeholder="e.g. Dundas & Adelaide, or Oxford & Wharncliffe"
                     />
                   </div>
 
                   <button onClick={() => setStep(3)} disabled={!title.trim()}
-                    className="w-full flex items-center justify-center gap-2 py-3 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
-                    style={{ background: 'var(--ink)', color: 'var(--card)', ...ds }}
+                    className="w-full flex items-center justify-center gap-2 py-3 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-all font-display btn-ink"
                   >Continue <ArrowRight className="w-4 h-4" /></button>
                 </div>
               )}
@@ -190,37 +186,37 @@ export function CreatePostForm({ onClose }: CreatePostFormProps) {
               {step === 3 && (
                 <div className="space-y-5 animate-fade-up">
                   <div>
-                    <label className="block text-xs font-bold uppercase tracking-wider mb-2" style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}>Your name</label>
+                    <label className="block text-xs font-bold uppercase tracking-wider mb-2 font-display color-ink-light" style={{ fontSize: '0.6rem' }}>Your name</label>
                     <input type="text" value={contactName} onChange={(e) => setContactName(e.target.value)}
-                      className="w-full px-4 py-3 text-sm focus:outline-none"
-                      style={{ background: '#fff', border: '1px solid var(--border-card)', color: 'var(--ink)' }}
+                      className="w-full px-4 py-3 text-sm focus:outline-none color-ink"
+                      style={{ background: '#fff', border: '1px solid var(--border-card)' }}
                       placeholder="First name" autoFocus
                     />
                   </div>
                   <div className="p-3" style={{ background: 'rgba(58,106,74,0.08)', border: '1px solid var(--border-card)' }}>
-                    <p className="text-xs" style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem', fontWeight: 'bold', textTransform: 'uppercase', letterSpacing: '0.1em' }}>How people connect with you</p>
-                    <p className="text-xs mt-1" style={{ color: 'var(--ink-muted)', fontSize: '0.75rem' }}>
+                    <p className="text-xs font-display color-ink-light" style={{ fontSize: '0.6rem', fontWeight: 'bold', textTransform: 'uppercase', letterSpacing: '0.1em' }}>How people connect with you</p>
+                    <p className="text-xs mt-1 color-ink-muted" style={{ fontSize: '0.75rem' }}>
                       Interested neighbours will reach out through the app. Your personal info stays private until you choose to share it.
                     </p>
                   </div>
 
                   {/* Preview */}
                   <div className="p-4" style={{ background: 'rgba(26,42,32,0.05)', border: '1px dashed var(--border-card)' }}>
-                    <p className="text-xs uppercase tracking-wider font-bold mb-1" style={{ ...ds, color: 'var(--ink-muted)', fontSize: '0.55rem' }}>Preview</p>
-                    <p className="text-sm" style={{ color: 'var(--ink)' }}>
+                    <p className="text-xs uppercase tracking-wider font-bold mb-1 font-display color-ink-muted" style={{ fontSize: '0.55rem' }}>Preview</p>
+                    <p className="text-sm color-ink">
                       <span className="font-bold" style={{ color: type === 'need' ? 'var(--need)' : 'var(--offer)' }}>
                         {type === 'need' ? 'Looking for' : 'Offering'}:
                       </span>{' '}{title || '...'}
                     </p>
-                    <p className="text-xs mt-1" style={{ color: 'var(--ink-muted)' }}>
+                    <p className="text-xs mt-1 color-ink-muted">
                       by {contactName || '...'}
                       {crossStreet && <span> · {crossStreet}</span>}
                     </p>
                   </div>
 
                   <button onClick={handleSubmit} disabled={submitting || !contactName.trim()}
-                    className="w-full py-4 text-sm font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
-                    style={{ background: type === 'need' ? 'var(--need)' : 'var(--offer)', color: 'var(--card)', ...ds }}
+                    className="w-full py-4 text-sm font-bold uppercase tracking-wider disabled:opacity-40 transition-all font-display color-card"
+                    style={{ background: type === 'need' ? 'var(--need)' : 'var(--offer)' }}
                   >{submitting ? 'Posting...' : 'Share with the community'}</button>
                 </div>
               )}

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -64,10 +64,9 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
 
         {/* Type label */}
         <div
-          className="text-xs font-bold uppercase tracking-wider mb-2"
+          className="text-xs font-bold uppercase tracking-wider mb-2 font-display"
           style={{
             color: isNeed ? 'var(--need)' : 'var(--offer)',
-            fontFamily: 'var(--font-display)',
             fontSize: '0.62rem',
             letterSpacing: '0.15em',
           }}
@@ -78,10 +77,8 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
         {/* Title */}
         <Link href={`/post/${post.id}`}>
           <h3
-            className="text-base leading-snug mb-1 hover:underline"
+            className="text-base leading-snug mb-1 hover:underline font-serif color-ink"
             style={{
-              color: 'var(--ink)',
-              fontFamily: 'var(--font-serif)',
               fontWeight: 400,
               lineHeight: 1.3,
             }}
@@ -93,8 +90,8 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
         {/* Details */}
         {post.details && (
           <p
-            className="text-sm leading-relaxed mb-2 line-clamp-2"
-            style={{ color: 'var(--ink)', fontSize: '0.88rem' }}
+            className="text-sm leading-relaxed mb-2 line-clamp-2 color-ink"
+            style={{ fontSize: '0.88rem' }}
           >
             {post.details}
           </p>
@@ -103,12 +100,12 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
         {/* Footer */}
         <div className="pt-2" style={{ borderTop: '1px dashed var(--border-card)' }}>
           {/* Meta row */}
-          <div className="flex items-center gap-1 flex-wrap mb-2" style={{ color: 'var(--ink-light)', fontSize: '0.72rem' }}>
+          <div className="flex items-center gap-1 flex-wrap mb-2 color-ink-light" style={{ fontSize: '0.72rem' }}>
             <span style={{ fontWeight: 600, color: 'var(--ink)' }}>{(post as any).profiles?.display_name || post.contact_name}</span>
             {(post as any).profiles?.neighbourhood && (
               <>
                 <span>&mdash;</span>
-                <span style={{ color: 'var(--offer)', fontFamily: 'var(--font-display)', fontSize: '0.6rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
+                <span className="font-display color-offer" style={{ fontSize: '0.6rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.08em' }}>
                   {(post as any).profiles.neighbourhood}
                 </span>
               </>
@@ -129,7 +126,7 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
             )}
 
             {post.responses.length > 0 && (
-              <span style={{ color: 'var(--ink-muted)', fontSize: '0.68rem' }}>
+              <span className="color-ink-muted" style={{ fontSize: '0.68rem' }}>
                 &mdash; {post.responses.length} {post.responses.length === 1 ? 'response' : 'responses'}
               </span>
             )}
@@ -138,12 +135,11 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
           {/* Action button */}
           <button
             onClick={(e) => { e.stopPropagation(); setShowRespond(true); }}
-            className="w-full py-2 text-xs font-bold uppercase tracking-wider transition-all"
+            className="w-full py-2 text-xs font-bold uppercase tracking-wider transition-all font-display"
             style={{
               border: `2px solid ${isNeed ? 'var(--need)' : 'var(--offer)'}`,
               color: isNeed ? 'var(--need)' : 'var(--offer)',
               background: 'transparent',
-              fontFamily: 'var(--font-display)',
               fontSize: '0.7rem',
               letterSpacing: '0.1em',
             }}
@@ -168,9 +164,8 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
           >
             {modDone ? (
               <div
-                className="text-center text-xs font-bold uppercase tracking-wider py-1"
+                className="text-center text-xs font-bold uppercase tracking-wider py-1 font-display"
                 style={{
-                  fontFamily: 'var(--font-display)',
                   color: modDone === 'approved' ? 'var(--offer)' : 'var(--need)',
                   fontSize: '0.6rem',
                   letterSpacing: '0.12em',
@@ -199,15 +194,14 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
                 <button
                   onClick={() => handleModerate('reject', rejectReason)}
                   disabled={moderating}
-                  className="px-2 py-1 text-xs font-bold uppercase disabled:opacity-40"
-                  style={{ background: 'var(--need)', color: 'white', fontFamily: 'var(--font-display)', fontSize: '0.6rem', letterSpacing: '0.08em' }}
+                  className="px-2 py-1 text-xs font-bold uppercase disabled:opacity-40 font-display"
+                  style={{ background: 'var(--need)', color: 'white', fontSize: '0.6rem', letterSpacing: '0.08em' }}
                 >
                   {moderating ? '…' : 'Reject'}
                 </button>
                 <button
                   onClick={() => setShowRejectInput(false)}
-                  className="px-1.5 py-1 text-xs"
-                  style={{ color: 'var(--ink-muted)' }}
+                  className="px-1.5 py-1 text-xs color-ink-muted"
                 >
                   ✕
                 </button>
@@ -217,9 +211,8 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
                 <button
                   onClick={() => handleModerate('approve')}
                   disabled={moderating}
-                  className="flex-1 py-1 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors"
+                  className="flex-1 py-1 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors font-display"
                   style={{
-                    fontFamily: 'var(--font-display)',
                     fontSize: '0.6rem',
                     letterSpacing: '0.1em',
                     background: 'var(--offer)',
@@ -231,9 +224,8 @@ export function PostCard({ post, index = 0, isModerator = false }: PostCardProps
                 <button
                   onClick={() => setShowRejectInput(true)}
                   disabled={moderating}
-                  className="flex-1 py-1 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors"
+                  className="flex-1 py-1 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors font-display"
                   style={{
-                    fontFamily: 'var(--font-display)',
                     fontSize: '0.6rem',
                     letterSpacing: '0.1em',
                     background: 'var(--need)',

--- a/src/components/post-feed.tsx
+++ b/src/components/post-feed.tsx
@@ -61,12 +61,11 @@ export function PostFeed({ initialPosts, isModerator = false }: PostFeedProps) {
       {filtered.length === 0 ? (
         <div className="text-center py-16 animate-fade-up w-full">
           <p
-            className="text-xl font-bold uppercase tracking-wide mb-2"
-            style={{ color: 'var(--heading)', fontFamily: 'var(--font-display)' }}
+            className="text-xl font-bold uppercase tracking-wide mb-2 font-display color-heading"
           >
             {posts.length === 0 ? 'The board is quiet' : 'Nothing matches'}
           </p>
-          <p className="text-sm mb-8" style={{ color: 'var(--sub)' }}>
+          <p className="text-sm mb-8 color-sub">
             {posts.length === 0
               ? 'Be the first to share something with your neighbours.'
               : 'Try adjusting your filters.'}

--- a/src/components/respond-dialog.tsx
+++ b/src/components/respond-dialog.tsx
@@ -76,35 +76,35 @@ export function RespondDialog({ post, open, onClose }: RespondDialogProps) {
 
   return (
     <div className="fixed inset-0 flex items-end sm:items-center justify-center z-50 animate-fade-in" style={{ background: 'rgba(0,0,0,0.5)' }} onClick={onClose}>
-      <div className="w-full max-w-md animate-slide-up sm:rounded-md" style={{ background: 'var(--card)' }} onClick={(e) => e.stopPropagation()}>
+      <div className="w-full max-w-md animate-slide-up sm:rounded-md bg-card" onClick={(e) => e.stopPropagation()}>
         {submitted ? (
           <div className="text-center py-16 px-6">
             <div className="text-3xl mb-4">🤝</div>
-            <p className="text-lg font-bold uppercase tracking-wide mb-2" style={{ fontFamily: 'var(--font-display)', color: 'var(--ink)' }}>
+            <p className="text-lg font-bold uppercase tracking-wide mb-2 font-display color-ink">
               {isNeed ? 'You\'re offering to help' : 'You\'re interested'}
             </p>
-            <p className="text-sm leading-relaxed" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-light)', fontStyle: 'italic' }}>
+            <p className="text-sm leading-relaxed font-serif color-ink-light" style={{ fontStyle: 'italic' }}>
               {post.contact_name} will hear from you soon.
             </p>
-            <p className="text-xs mt-4" style={{ color: 'var(--ink-muted)' }}>This is how communities work.</p>
+            <p className="text-xs mt-4 color-ink-muted">This is how communities work.</p>
           </div>
         ) : (
           <div className="p-6">
             <div className="flex items-start justify-between mb-5">
               <div>
-                <h3 className="text-sm font-bold uppercase tracking-wide" style={{ fontFamily: 'var(--font-display)', color: 'var(--ink)' }}>
+                <h3 className="text-sm font-bold uppercase tracking-wide font-display color-ink">
                   {isNeed ? 'Offer to help' : 'Express interest'}
                 </h3>
-                <p className="text-xs mt-1 italic" style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink-muted)' }}>Re: {post.title}</p>
+                <p className="text-xs mt-1 italic font-serif color-ink-muted">Re: {post.title}</p>
               </div>
-              <button onClick={onClose} className="p-1" style={{ color: 'var(--ink-muted)' }}><X className="w-4 h-4" /></button>
+              <button onClick={onClose} className="p-1 color-ink-muted"><X className="w-4 h-4" /></button>
             </div>
             <form onSubmit={handleSubmit} className="space-y-4">
               <Field label="Your name" value={name} onChange={setName} placeholder="First name" required autoFocus />
               <Field label="Message" value={message} onChange={setMessage} placeholder="Anything you want them to know... you can include your contact info here if you'd like." optional textarea />
               <div className="flex gap-3 pt-1">
-                <button type="button" onClick={onClose} className="flex-1 py-3 text-xs font-bold uppercase tracking-wider" style={{ border: '1.5px solid var(--border-card)', color: 'var(--ink-light)' }}>Cancel</button>
-                <button type="submit" disabled={submitting || !name.trim()} className="flex-1 py-3 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors" style={{ background: isNeed ? 'var(--need)' : 'var(--offer)', color: 'var(--card)', fontFamily: 'var(--font-display)' }}>
+                <button type="button" onClick={onClose} className="flex-1 py-3 text-xs font-bold uppercase tracking-wider color-ink-light" style={{ border: '1.5px solid var(--border-card)' }}>Cancel</button>
+                <button type="submit" disabled={submitting || !name.trim()} className="flex-1 py-3 text-xs font-bold uppercase tracking-wider disabled:opacity-40 transition-colors font-display color-card" style={{ background: isNeed ? 'var(--need)' : 'var(--offer)' }}>
                   {submitting ? 'Sending...' : 'Send'}
                 </button>
               </div>
@@ -120,14 +120,14 @@ function Field({ label, value, onChange, placeholder, required, optional, autoFo
   const Tag = textarea ? 'textarea' : 'input';
   return (
     <div>
-      <label className="block text-xs font-bold uppercase tracking-wider mb-1.5" style={{ fontFamily: 'var(--font-display)', color: 'var(--ink-light)', fontSize: '0.6rem' }}>
-        {label} {optional && <span className="normal-case tracking-normal font-normal" style={{ color: 'var(--ink-muted)' }}>(optional)</span>}
+      <label className="block text-xs font-bold uppercase tracking-wider mb-1.5 font-display color-ink-light" style={{ fontSize: '0.6rem' }}>
+        {label} {optional && <span className="normal-case tracking-normal font-normal color-ink-muted">(optional)</span>}
       </label>
       <Tag
         value={value}
         onChange={(e: any) => onChange(e.target.value)}
-        className="w-full px-4 py-3 text-sm focus:outline-none transition-all"
-        style={{ background: '#fff', border: '1px solid var(--border-card)', color: 'var(--ink)', fontFamily: 'var(--font-body)' }}
+        className="w-full px-4 py-3 text-sm focus:outline-none transition-all font-body color-ink"
+        style={{ background: '#fff', border: '1px solid var(--border-card)' }}
         placeholder={placeholder}
         required={required}
         autoFocus={autoFocus}


### PR DESCRIPTION
Replaces inline `style={}` attributes across 14 files with CSS classes defined in globals.css.

**What changed:**
- Added 45 utility CSS classes to globals.css (font, bg, color, border, form, button, card, glow helpers)
- Removed `const ds` / `const sr` shorthand variables from 6 components
- Replaced static inline styles with class equivalents across all pages and components
- Kept all dynamic/conditional styles inline (ternaries based on post type, etc.)

**Net result:** 239 insertions, 276 deletions — fewer lines, more maintainable, fully theme-consistent.

Closes #11