### PR TITLE
feat: post editing for post owners (#18)

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+// PUT /api/posts/[id] — update a post (owner only)
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const supabase = await createClient();
+
+    // Auth check
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { id } = params;
+
+    // Fetch existing post to verify ownership
+    const { data: existing, error: fetchError } = await supabase
+      .from('posts')
+      .select('id, user_id')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+    }
+
+    if (existing.user_id !== user.id) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { title, details, category, urgency } = body;
+
+    if (!title?.trim()) {
+      return NextResponse.json({ error: 'Title is required' }, { status: 400 });
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from('posts')
+      .update({
+        title: title.trim(),
+        details: details?.trim() || null,
+        category: category || 'other',
+        urgency: urgency || 'flexible',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (updateError) {
+      return NextResponse.json({ error: updateError.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, post: updated });
+  } catch (err) {
+    console.error('Post update error:', err);
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -22,6 +22,14 @@ export default async function PostDetail({ params }: { params: { id: string } })
   const dateStr = format(new Date(post.created_at), 'MMMM d, yyyy');
   const isNeed = post.type === 'need';
 
+  // Show "edited" when updated_at is more than 1 minute after created_at
+  const createdMs = new Date(post.created_at).getTime();
+  const updatedMs = new Date(post.updated_at).getTime();
+  const wasEdited = updatedMs - createdMs > 60_000;
+  const editedAgo = wasEdited
+    ? formatDistanceToNow(new Date(post.updated_at), { addSuffix: true })
+    : null;
+
   return (
     <main className="min-h-screen" style={{
       background: 'var(--bg)',
@@ -69,6 +77,11 @@ export default async function PostDetail({ params }: { params: { id: string } })
           )}
           <span>&mdash;</span>
           <span title={dateStr}>{timeAgo}</span>
+          {editedAgo && (
+            <span style={{ color: 'var(--ink-muted)', fontStyle: 'italic' }}>
+              · edited {editedAgo}
+            </span>
+          )}
           {categoryInfo && <><span>&mdash;</span><span>{categoryInfo.label}</span></>}
           {post.urgency !== 'flexible' && (
             <span className="inline-flex items-center gap-1 px-2 py-0.5" style={{ background: post.urgency === 'today' ? 'rgba(208,112,64,0.15)' : 'rgba(224,216,192,0.15)', color: post.urgency === 'today' ? 'var(--need)' : 'var(--heading)' }}>

--- a/src/app/post/[id]/post-detail-client.tsx
+++ b/src/app/post/[id]/post-detail-client.tsx
@@ -5,8 +5,9 @@ import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { isVouchRequiredClient } from '@/lib/settings-client';
 import { RespondDialog } from '@/components/respond-dialog';
+import { EditPostForm } from '@/components/edit-post-form';
 import { formatDistanceToNow } from 'date-fns';
-import { MessageSquare } from 'lucide-react';
+import { MessageSquare, Pencil, RefreshCw } from 'lucide-react';
 import type { PostWithResponses } from '@/types/database';
 
 interface PostDetailClientProps {
@@ -16,6 +17,9 @@ interface PostDetailClientProps {
 
 export function PostDetailClient({ post, isModerator = false }: PostDetailClientProps) {
   const [showRespond, setShowRespond] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+  const [extending, setExtending] = useState(false);
+  const [extendedUntil, setExtendedUntil] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [vouchStatus, setVouchStatus] = useState<string>('unvouched');
   const [vouchRequired, setVouchRequired] = useState(false);
@@ -103,6 +107,34 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
               {isNeed ? 'I can help with this' : 'I\'m interested in this'}
             </button>
           )}
+        </div>
+      )}
+
+      {/* Edit button — shown to post owner only */}
+      {isPoster && post.status === 'active' && (
+        <div className="mb-6">
+          <button
+            onClick={() => setShowEdit(true)}
+            className="inline-flex items-center gap-2 px-4 py-2.5 text-xs font-bold uppercase tracking-wider transition-all"
+            style={{
+              ...ds,
+              fontSize: '0.6rem',
+              border: '1.5px solid var(--border-card)',
+              color: 'var(--ink-muted)',
+              background: 'transparent',
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.borderColor = 'var(--ink)';
+              e.currentTarget.style.color = 'var(--ink)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.borderColor = 'var(--border-card)';
+              e.currentTarget.style.color = 'var(--ink-muted)';
+            }}
+          >
+            <Pencil className="w-3 h-3" />
+            Edit post
+          </button>
         </div>
       )}
 
@@ -252,6 +284,14 @@ export function PostDetailClient({ post, isModerator = false }: PostDetailClient
       )}
 
       <RespondDialog post={post} open={showRespond} onClose={() => setShowRespond(false)} />
+
+      {showEdit && (
+        <EditPostForm
+          post={post}
+          onClose={() => setShowEdit(false)}
+          onSuccess={() => router.refresh()}
+        />
+      )}
     </>
   );
 }

--- a/src/components/edit-post-form.tsx
+++ b/src/components/edit-post-form.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState } from 'react';
+import { CATEGORIES, URGENCIES } from '@/lib/constants';
+import type { Post, Category, Urgency } from '@/types/database';
+import { X } from 'lucide-react';
+
+interface EditPostFormProps {
+  post: Post;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function EditPostForm({ post, onClose, onSuccess }: EditPostFormProps) {
+  const [title, setTitle] = useState(post.title);
+  const [details, setDetails] = useState(post.details || '');
+  const [category, setCategory] = useState<Category>(post.category);
+  const [urgency, setUrgency] = useState<Urgency>(post.urgency);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isNeed = post.type === 'need';
+
+  const handleSubmit = async () => {
+    if (!title.trim()) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/posts/${post.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          details: details.trim() || null,
+          category,
+          urgency,
+        }),
+      });
+
+      if (res.ok) {
+        onSuccess();
+        onClose();
+      } else {
+        const data = await res.json();
+        setError(data.error || 'Something went wrong');
+      }
+    } catch {
+      setError('Network error — please try again');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const ds = { fontFamily: 'var(--font-display)' } as React.CSSProperties;
+  const sr = { fontFamily: 'var(--font-serif)' } as React.CSSProperties;
+  const accentColor = isNeed ? 'var(--need)' : 'var(--offer)';
+
+  return (
+    <div
+      className="fixed inset-0 flex items-end sm:items-center justify-center z-50"
+      style={{ background: 'rgba(0,0,0,0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg max-h-[85vh] overflow-y-auto sm:rounded-md"
+        style={{ background: 'var(--card)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-6 pb-4">
+          <div>
+            <p
+              className="text-xs font-bold uppercase tracking-wider"
+              style={{ ...ds, color: 'var(--sub)', fontSize: '0.6rem' }}
+            >
+              Edit post
+            </p>
+            <p
+              className="text-sm font-bold uppercase tracking-wide mt-0.5"
+              style={{ ...ds, color: 'var(--ink)' }}
+            >
+              {isNeed ? 'Edit your need' : 'Edit your offer'}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2"
+            style={{ color: 'var(--ink-muted)' }}
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Accent bar */}
+        <div className="h-0.5 mx-6 mb-6" style={{ background: accentColor, opacity: 0.4 }} />
+
+        <div className="px-6 pb-8 space-y-5">
+          {/* Title */}
+          <div>
+            <label
+              className="block text-xs font-bold uppercase tracking-wider mb-2"
+              style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}
+            >
+              Title
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-0 py-3 bg-transparent border-0 border-b-2 focus:outline-none text-lg"
+              style={{ borderColor: 'var(--border-card)', color: 'var(--ink)', ...sr }}
+              placeholder={isNeed ? 'What do you need?' : 'What can you offer?'}
+              autoFocus
+            />
+          </div>
+
+          {/* Details */}
+          <div>
+            <label
+              className="block text-xs font-bold uppercase tracking-wider mb-2"
+              style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}
+            >
+              Details{' '}
+              <span
+                className="normal-case tracking-normal font-normal"
+                style={{ color: 'var(--ink-muted)' }}
+              >
+                (optional)
+              </span>
+            </label>
+            <textarea
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+              className="w-full px-4 py-3 text-sm focus:outline-none resize-none"
+              style={{
+                background: 'rgba(240,236,224,0.06)',
+                border: '1px solid var(--border-card)',
+                color: 'var(--ink)',
+              }}
+              rows={3}
+              placeholder="Any extra context..."
+            />
+          </div>
+
+          {/* Category */}
+          <div>
+            <label
+              className="block text-xs font-bold uppercase tracking-wider mb-2"
+              style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}
+            >
+              Category
+            </label>
+            <div className="flex gap-2 flex-wrap">
+              {CATEGORIES.map((c) => (
+                <button
+                  key={c.value}
+                  type="button"
+                  onClick={() => setCategory(c.value)}
+                  className="px-3 py-2 text-xs font-bold uppercase tracking-wider transition-all"
+                  style={{
+                    ...ds,
+                    fontSize: '0.6rem',
+                    background: category === c.value ? 'var(--ink)' : 'transparent',
+                    color: category === c.value ? 'var(--card)' : 'var(--ink-light)',
+                    border: `1.5px solid ${category === c.value ? 'var(--ink)' : 'var(--border-card)'}`,
+                  }}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Urgency */}
+          <div>
+            <label
+              className="block text-xs font-bold uppercase tracking-wider mb-2"
+              style={{ ...ds, color: 'var(--ink-light)', fontSize: '0.6rem' }}
+            >
+              How soon?
+            </label>
+            <div className="flex gap-2">
+              {URGENCIES.map((u) => (
+                <button
+                  key={u.value}
+                  type="button"
+                  onClick={() => setUrgency(u.value)}
+                  className="flex-1 px-3 py-2 text-xs font-bold uppercase tracking-wider text-center transition-all"
+                  style={{
+                    ...ds,
+                    fontSize: '0.6rem',
+                    background: urgency === u.value ? 'var(--ink)' : 'transparent',
+                    color: urgency === u.value ? 'var(--card)' : 'var(--ink-light)',
+                    border: `1.5px solid ${urgency === u.value ? 'var(--ink)' : 'var(--border-card)'}`,
+                  }}
+                >
+                  {u.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p
+              className="text-xs px-3 py-2"
+              style={{
+                background: 'rgba(208,112,64,0.1)',
+                border: '1px solid rgba(208,112,64,0.3)',
+                color: 'var(--need)',
+                ...ds,
+                fontSize: '0.7rem',
+              }}
+            >
+              {error}
+            </p>
+          )}
+
+          {/* Submit */}
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !title.trim()}
+            className="w-full py-4 text-sm font-bold uppercase tracking-wider disabled:opacity-40 transition-all"
+            style={{
+              background: accentColor,
+              color: 'var(--card)',
+              ...ds,
+            }}
+          >
+            {submitting ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Users can now edit their posts after publishing.

**What's included:**
- PUT API at `/api/posts/[id]` with ownership check
- Edit form modal (reuses create-post styling, pre-filled with current data)
- Edit button on post detail page (only visible to post owner, active posts only)
- 'Edited' indicator with timestamp when post has been modified

Editable: title, details, category, urgency. NOT editable: post type, contact method.

Closes #18