### PR TITLE
fix: nav polish — mobile cutoff, hover effects, theme cleanup, admin link

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -156,11 +156,23 @@
   font-family: var(--font-display);
   letter-spacing: 0.1em;
 }
+.nav-link:hover {
+  color: var(--heading);
+  text-decoration: underline;
+  text-underline-offset: 0.25rem;
+}
 .nav-icon {
   color: var(--sub);
 }
+.nav-icon:hover {
+  color: var(--heading);
+}
 .nav-icon-active {
   color: var(--offer);
+}
+.nav-icon-active:hover {
+  color: var(--offer);
+  filter: brightness(1.2);
 }
 .nav-badge {
   background: var(--need);

--- a/src/components/filter-bar.tsx
+++ b/src/components/filter-bar.tsx
@@ -18,7 +18,7 @@ export function FilterBar({ typeFilter, categoryFilter, onTypeChange, onCategory
   return (
     <div className="space-y-2 animate-fade-up">
       {/* Type filters + category filters on one row on mobile */}
-      <div className="flex items-center justify-center gap-x-2 md:gap-x-5 flex-nowrap overflow-x-auto pb-1 md:pb-3 w-full" style={{ scrollbarWidth: 'none' }}>
+      <div className="flex items-center justify-center gap-x-3 md:gap-x-5 flex-wrap pb-1 md:pb-3 w-full">
         {POST_TYPES.map((t) => (
           <Tag
             key={t.value}
@@ -67,7 +67,7 @@ function Tag({ active, onClick, label, activeColor }: {
       className="font-bold uppercase tracking-wider whitespace-nowrap flex-shrink-0 transition-all"
       style={{
         fontFamily: 'var(--font-display)',
-        fontSize: 'clamp(0.6rem, 0.6rem + 0.4vw, 1.1rem)',
+        fontSize: 'clamp(0.65rem, 0.6rem + 0.4vw, 1.1rem)',
         letterSpacing: '0.06em',
         color: active
           ? (activeColor || 'var(--heading)')

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { CreatePostForm } from './create-post-form';
 import { ThemeToggle } from './theme-toggle';
-import { Search, Map, User, MessageSquare } from 'lucide-react';
+import { Search, Map, User, MessageSquare, Shield } from 'lucide-react';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
 
@@ -12,12 +12,17 @@ export function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
   const [unread, setUnread] = useState(0);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     const supabase = createClient();
     supabase.auth.getUser().then(({ data: { user } }) => {
       setIsLoggedIn(!!user);
       setUserId(user?.id || null);
+      if (user?.email) {
+        supabase.from('moderators').select('role').eq('email', user.email).single()
+          .then(({ data }) => { if (data) setIsAdmin(true); });
+      }
     });
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => {
       setIsLoggedIn(!!session?.user);
@@ -69,20 +74,20 @@ export function Header() {
           </Link>
 
           <div className="flex items-center gap-1 md:gap-3">
-            <Link href="/about" className="nav-link hidden md:inline-block px-2 py-1 text-xs font-bold uppercase tracking-wider transition-colors">
+            <Link href="/about" className="nav-link hidden md:inline-block px-2 py-1 text-xs font-bold uppercase tracking-wider transition-all hover:opacity-100">
               About
             </Link>
-            <Link href="/feedback" className="nav-link hidden md:inline-block px-2 py-1 text-xs font-bold uppercase tracking-wider transition-colors">
+            <Link href="/feedback" className="nav-link hidden md:inline-block px-2 py-1 text-xs font-bold uppercase tracking-wider transition-all hover:opacity-100">
               Feedback
             </Link>
-            <Link href="/search" className="nav-icon p-2 md:p-3 rounded transition-colors">
+            <Link href="/search" className="nav-icon p-2 md:p-3 rounded transition-all hover:opacity-100 hover:scale-110">
               <Search className="w-4 h-4 md:w-7 md:h-7" />
             </Link>
-            <Link href="/map" className="nav-icon p-2 md:p-3 rounded transition-colors">
+            <Link href="/map" className="nav-icon p-2 md:p-3 rounded transition-all hover:opacity-100 hover:scale-110">
               <Map className="w-4 h-4 md:w-7 md:h-7" />
             </Link>
             {isLoggedIn && (
-              <Link href="/messages" className={`relative p-2 md:p-3 rounded transition-colors ${unread > 0 ? 'nav-icon-active' : 'nav-icon'}`}>
+              <Link href="/messages" className={`relative p-2 md:p-3 rounded transition-all hover:opacity-100 hover:scale-110 ${unread > 0 ? 'nav-icon-active' : 'nav-icon'}`}>
                 <MessageSquare className="w-4 h-4 md:w-7 md:h-7" />
                 {unread > 0 && (
                   <span className="nav-badge absolute top-1 right-1 md:top-1.5 md:right-1.5 flex items-center justify-center text-white font-bold">
@@ -91,7 +96,12 @@ export function Header() {
                 )}
               </Link>
             )}
-            <Link href={isLoggedIn ? '/account' : '/auth'} className={`p-2 md:p-3 rounded transition-colors ${isLoggedIn ? 'nav-icon-active' : 'nav-icon'}`}>
+            {isAdmin && (
+              <Link href="/admin" className="nav-icon p-2 md:p-3 rounded transition-all hover:opacity-100 hover:scale-110 hover:opacity-100 hover:scale-110" title="Admin">
+                <Shield className="w-4 h-4 md:w-7 md:h-7" />
+              </Link>
+            )}
+            <Link href={isLoggedIn ? '/account' : '/auth'} className={`p-2 md:p-3 rounded transition-colors hover:opacity-100 hover:scale-110 ${isLoggedIn ? 'nav-icon-active' : 'nav-icon'}`}>
               <User className="w-4 h-4 md:w-7 md:h-7" />
             </Link>
             <ThemeToggle />
@@ -100,7 +110,7 @@ export function Header() {
                 if (isLoggedIn === null) return;
                 isLoggedIn ? setShowCreate(true) : window.location.href = '/auth?next=/';
               }}
-              className="post-btn ml-1 px-4 py-2 md:ml-2 md:px-7 md:py-3 text-xs md:text-base font-bold uppercase tracking-wider transition-colors"
+              className="post-btn ml-1 px-4 py-2 md:ml-2 md:px-7 md:py-3 text-xs md:text-base font-bold uppercase tracking-wider transition-all hover:scale-105 hover:brightness-110"
             >
               Post
             </button>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -3,9 +3,8 @@
 import { useState, useEffect, useRef } from 'react';
 
 const THEMES = [
-  { id: 'forest-dark', label: 'Forest Dark', swatch: '#1a2a20' },
-  { id: 'light', label: 'Light', swatch: '#faf8f4' },
   { id: 'evergreen', label: 'Evergreen', swatch: '#1e3a28' },
+  { id: 'light', label: 'Light', swatch: '#faf8f4' },
   { id: 'slate', label: 'Slate', swatch: '#22222a' },
   { id: 'parchment', label: 'Parchment', swatch: '#f5f0e0' },
 ] as const;
@@ -13,8 +12,11 @@ const THEMES = [
 type ThemeId = typeof THEMES[number]['id'];
 
 function getStoredTheme(): ThemeId {
-  if (typeof window === 'undefined') return 'forest-dark';
-  return (localStorage.getItem('flourish-theme') as ThemeId) || 'forest-dark';
+  if (typeof window === 'undefined') return 'evergreen';
+  const stored = localStorage.getItem('flourish-theme') as ThemeId;
+  // Migrate forest-dark users to evergreen
+  if (!stored || stored === ('forest-dark' as string)) return 'evergreen';
+  return stored;
 }
 
 function applyTheme(id: ThemeId) {


### PR DESCRIPTION
Four fixes:

1. **Mobile text cutoff**: Filter bar now wraps instead of overflowing. 'Needs' and 'Other' no longer cut off on small screens.
2. **Desktop hover effects**: All nav icons scale up on hover (1.1x), text links get underline + color change, Post button scales + brightens. CSS hover states added for .nav-icon and .nav-link.
3. **Removed Forest Dark theme**: Too similar to Evergreen. Default is now Evergreen. Users on Forest Dark auto-migrated.
4. **Admin link**: Shield icon in nav bar when a moderator/admin is logged in. Links to /admin.